### PR TITLE
Implement `DoubleEndedIterator` for `SmallVec`

### DIFF
--- a/src/smallvec.rs
+++ b/src/smallvec.rs
@@ -270,7 +270,25 @@ impl<'a,T> Iterator for SmallVecIterator<'a,T> {
     }
 }
 
-pub struct SmallVecMutIterator<'a,T> {
+impl<'a,T> DoubleEndedIterator for SmallVecIterator<'a,T> {
+    #[inline]
+    fn next_back(&mut self) -> Option<&'a T> {
+        unsafe {
+            if self.ptr == self.end {
+                return None
+            }
+            let old = self.end;
+            self.end = if mem::size_of::<T>() == 0 {
+                mem::transmute(self.end as uint - 1)
+            } else {
+                self.end.offset(-1)
+            };
+            Some(mem::transmute(self.end))
+        }
+    }
+}
+
+pub struct SmallVecMutIterator<'a, T: 'a> {
     ptr: *mut T,
     end: *mut T,
     lifetime: ContravariantLifetime<'a>,


### PR DESCRIPTION
This is based against 1e5bbf16eee3adeec1e911c7eaa8f2be02cd4c67, which is the revision that Servo uses.

r? @SimonSapin 
