### PR TITLE
Switch to the FNV hash from Servo.

### DIFF
--- a/src/fnv.rs
+++ b/src/fnv.rs
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! This file stolen wholesale from rustc/src/librustc/util/nodemap.rs
+
+use std::default::Default;
+use std::hash::Hasher;
+use std::num::wrapping::WrappingOps;
+
+/// A speedy hash algorithm for node ids and def ids. The hashmap in
+/// libcollections by default uses SipHash which isn't quite as speedy as we
+/// want. In the compiler we're not really worried about DOS attempts, so we
+/// just default to a non-cryptographic hash.
+///
+/// This uses FNV hashing, as described here:
+/// http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+#[allow(missing_copy_implementations)]
+pub struct FnvHasher(u64);
+
+impl Default for FnvHasher {
+    #[inline]
+    fn default() -> FnvHasher { FnvHasher(0xcbf29ce484222325) }
+}
+
+impl Hasher for FnvHasher {
+    #[inline]
+    fn finish(&self) -> u64 { self.0 }
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let FnvHasher(mut hash) = *self;
+        for byte in bytes.iter() {
+            hash = hash ^ (*byte as u64);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        *self = FnvHasher(hash);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 extern crate string_cache;
 
 pub mod bloom;
+pub mod fnv;
 pub mod matching;
 pub mod parser;
 pub mod quicksort;

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -5,6 +5,8 @@
 use std::ascii::AsciiExt;
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::collections::hash_state::{DefaultState, HashState};
+use std::default::Default;
 use std::sync::Arc;
 
 use bloom::BloomFilter;
@@ -12,9 +14,10 @@ use smallvec::VecLike;
 use quicksort::quicksort_by;
 use string_cache::Atom;
 
-use tree::{TElement, TNode};
+use fnv::FnvHasher;
 use parser::{CaseSensitivity, Combinator, CompoundSelector, LocalName};
 use parser::{SimpleSelector, Selector};
+use tree::{TElement, TNode};
 
 /// The definition of whitespace per CSS Selectors Level 3 § 4.
 pub static SELECTOR_WHITESPACE: &'static [char] = &[' ', '\t', '\n', '\r', '\x0C'];
@@ -40,12 +43,12 @@ pub static SELECTOR_WHITESPACE: &'static [char] = &[' ', '\t', '\n', '\r', '\x0C
 /// node.
 pub struct SelectorMap<T> {
     // TODO: Tune the initial capacity of the HashMap
-    id_hash: HashMap<Atom, Vec<Rule<T>>>,
-    class_hash: HashMap<Atom, Vec<Rule<T>>>,
-    local_name_hash: HashMap<Atom, Vec<Rule<T>>>,
+    id_hash: HashMap<Atom, Vec<Rule<T>>, DefaultState<FnvHasher>>,
+    class_hash: HashMap<Atom, Vec<Rule<T>>, DefaultState<FnvHasher>>,
+    local_name_hash: HashMap<Atom, Vec<Rule<T>>, DefaultState<FnvHasher>>,
     /// Same as local_name_hash, but keys are lower-cased.
     /// For HTML elements in HTML documents.
-    lower_local_name_hash: HashMap<Atom, Vec<Rule<T>>>,
+    lower_local_name_hash: HashMap<Atom, Vec<Rule<T>>, DefaultState<FnvHasher>>,
     // For Rules that don't have ID, class, or element selectors.
     universal_rules: Vec<Rule<T>>,
     /// Whether this hash is empty.
@@ -55,10 +58,10 @@ pub struct SelectorMap<T> {
 impl<T> SelectorMap<T> {
     pub fn new() -> SelectorMap<T> {
         SelectorMap {
-            id_hash: HashMap::new(),
-            class_hash: HashMap::new(),
-            local_name_hash: HashMap::new(),
-            lower_local_name_hash: HashMap::new(),
+            id_hash: HashMap::with_hash_state(Default::default()),
+            class_hash: HashMap::with_hash_state(Default::default()),
+            local_name_hash: HashMap::with_hash_state(Default::default()),
+            lower_local_name_hash: HashMap::with_hash_state(Default::default()),
             universal_rules: vec!(),
             empty: true,
         }
@@ -131,7 +134,9 @@ impl<T> SelectorMap<T> {
 
     fn get_matching_rules_from_hash<'a,N,V>(node: &N,
                                             parent_bf: &Option<Box<BloomFilter>>,
-                                            hash: &HashMap<Atom, Vec<Rule<T>>>,
+                                            hash: &HashMap<Atom,
+                                                           Vec<Rule<T>>,
+                                                           DefaultState<FnvHasher>>,
                                             key: &Atom,
                                             matching_rules: &mut V,
                                             shareable: &mut bool)
@@ -888,7 +893,9 @@ fn matches_last_child<'a,N>(element: &N) -> bool where N: TNode<'a> {
     }
 }
 
-fn find_push<T>(map: &mut HashMap<Atom, Vec<Rule<T>>>, key: Atom, value: Rule<T>) {
+fn find_push<T>(map: &mut HashMap<Atom, Vec<Rule<T>>, DefaultState<FnvHasher>>,
+                key: Atom,
+                value: Rule<T>) {
     match map.get_mut(&key) {
         Some(vec) => {
             vec.push(value);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,16 +6,19 @@ use std::ascii::{AsciiExt, OwnedAsciiExt};
 use std::borrow::Cow;
 use std::cmp;
 use std::collections::HashMap;
+use std::collections::hash_state::DefaultState;
+use std::default::Default;
 use std::sync::Arc;
 
 use cssparser::{Token, Parser, parse_nth};
 use string_cache::{Atom, Namespace};
 
+use fnv::FnvHasher;
 
 pub struct ParserContext {
     pub in_user_agent_stylesheet: bool,
     pub default_namespace: Option<Namespace>,
-    pub namespace_prefixes: HashMap<String, Namespace>,
+    pub namespace_prefixes: HashMap<String, Namespace, DefaultState<FnvHasher>>,
 }
 
 impl ParserContext {
@@ -23,7 +26,7 @@ impl ParserContext {
         ParserContext {
             in_user_agent_stylesheet: false,
             default_namespace: None,
-            namespace_prefixes: HashMap::new(),
+            namespace_prefixes: HashMap::with_hash_state(Default::default()),
         }
     }
 }


### PR DESCRIPTION
In Facebook Timeline, SipHash related functions were in the top 10
hottest functions of profile. This kicks them out. The overall layout
performance difference is in the noise, but it seems to be a win
nonetheless.

r? @SimonSapin 
