### PR TITLE
Remove the get_attr and get_attrs methods from TElement.

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -37,8 +37,6 @@ pub trait TNode<'a>: Clone + Copy {
 }
 
 pub trait TElement<'a>: Copy {
-    fn get_attr(self, namespace: &Namespace, attr: &Atom) -> Option<&'a str>;
-    fn get_attrs(self, attr: &Atom) -> Vec<&'a str>;
     fn get_link(self) -> Option<&'a str>;
     fn get_local_name(self) -> &'a Atom;
     fn get_namespace(self) -> &'a Namespace;


### PR DESCRIPTION
They are unused in this library, and cannot be implemented safely in Servo.
(get_link cannot be implemented safely either, but it is called in this
library, although the result is ignored.)
