### PR TITLE
Don’t require TNode and TElement implementors to be Copy.

### DIFF
--- a/src/matching.rs
+++ b/src/matching.rs
@@ -72,12 +72,12 @@ impl<T> SelectorMap<T> {
     /// Extract matching rules as per node's ID, classes, tag name, etc..
     /// Sort the Rules at the end to maintain cascading order.
     pub fn get_all_matching_rules<N,V>(&self,
-                                          node: &N,
-                                          parent_bf: &Option<Box<BloomFilter>>,
-                                          matching_rules_list: &mut V,
-                                          shareable: &mut bool)
-                                          where N: TNode,
-                                                V: VecLike<DeclarationBlock<T>> {
+                                       node: &N,
+                                       parent_bf: &Option<Box<BloomFilter>>,
+                                       matching_rules_list: &mut V,
+                                       shareable: &mut bool)
+                                       where N: TNode,
+                                             V: VecLike<DeclarationBlock<T>> {
         if self.empty {
             return
         }
@@ -133,15 +133,15 @@ impl<T> SelectorMap<T> {
     }
 
     fn get_matching_rules_from_hash<N,V>(node: &N,
-                                            parent_bf: &Option<Box<BloomFilter>>,
-                                            hash: &HashMap<Atom,
-                                                           Vec<Rule<T>>,
-                                                           DefaultState<FnvHasher>>,
-                                            key: &Atom,
-                                            matching_rules: &mut V,
-                                            shareable: &mut bool)
-                                            where N: TNode,
-                                                  V: VecLike<DeclarationBlock<T>> {
+                                         parent_bf: &Option<Box<BloomFilter>>,
+                                         hash: &HashMap<Atom,
+                                                        Vec<Rule<T>>,
+                                                        DefaultState<FnvHasher>>,
+                                         key: &Atom,
+                                         matching_rules: &mut V,
+                                         shareable: &mut bool)
+                                         where N: TNode,
+                                               V: VecLike<DeclarationBlock<T>> {
         match hash.get(key) {
             Some(rules) => {
                 SelectorMap::get_matching_rules(node,
@@ -156,12 +156,12 @@ impl<T> SelectorMap<T> {
 
     /// Adds rules in `rules` that match `node` to the `matching_rules` list.
     fn get_matching_rules<N,V>(node: &N,
-                                  parent_bf: &Option<Box<BloomFilter>>,
-                                  rules: &[Rule<T>],
-                                  matching_rules: &mut V,
-                                  shareable: &mut bool)
-                                  where N: TNode,
-                                        V: VecLike<DeclarationBlock<T>> {
+                               parent_bf: &Option<Box<BloomFilter>>,
+                               rules: &[Rule<T>],
+                               matching_rules: &mut V,
+                               shareable: &mut bool)
+                               where N: TNode,
+                                     V: VecLike<DeclarationBlock<T>> {
         for rule in rules.iter() {
             if matches_compound_selector(&*rule.selector, node, parent_bf, shareable) {
                 matching_rules.push(rule.declarations.clone());
@@ -301,10 +301,10 @@ impl<T> DeclarationBlock<T> {
 }
 
 pub fn matches<N>(selector_list: &Vec<Selector>,
-                     element: &N,
-                     parent_bf: &Option<Box<BloomFilter>>)
-                     -> bool
-                     where N: TNode {
+                  element: &N,
+                  parent_bf: &Option<Box<BloomFilter>>)
+                  -> bool
+                  where N: TNode {
     selector_list.iter().any(|selector| {
         selector.pseudo_element.is_none() &&
         matches_compound_selector(&*selector.compound_selectors, element, parent_bf, &mut false)
@@ -318,11 +318,11 @@ pub fn matches<N>(selector_list: &Vec<Selector>,
 /// will almost certainly break as nodes will start mistakenly sharing styles. (See the code in
 /// `main/css/matching.rs`.)
 fn matches_compound_selector<N>(selector: &CompoundSelector,
-                                   element: &N,
-                                   parent_bf: &Option<Box<BloomFilter>>,
-                                   shareable: &mut bool)
-                                   -> bool
-                                   where N: TNode {
+                                element: &N,
+                                parent_bf: &Option<Box<BloomFilter>>,
+                                shareable: &mut bool)
+                                -> bool
+                                where N: TNode {
     match matches_compound_selector_internal(selector, element, parent_bf, shareable) {
         SelectorMatchingResult::Matched => true,
         _ => false
@@ -383,11 +383,11 @@ enum SelectorMatchingResult {
 /// work on. If the simple selectors don't match, or there's a child selector
 /// that does not appear in the bloom parent bloom filter, we can exit early.
 fn can_fast_reject<N>(mut selector: &CompoundSelector,
-                         element: &N,
-                         parent_bf: &Option<Box<BloomFilter>>,
-                         shareable: &mut bool)
-                         -> Option<SelectorMatchingResult>
-                         where N: TNode {
+                      element: &N,
+                      parent_bf: &Option<Box<BloomFilter>>,
+                      shareable: &mut bool)
+                      -> Option<SelectorMatchingResult>
+                      where N: TNode {
     if !selector.simple_selectors.iter().all(|simple_selector| {
       matches_simple_selector(simple_selector, element, shareable) }) {
         return Some(SelectorMatchingResult::NotMatchedAndRestartFromClosestLaterSibling);
@@ -444,11 +444,11 @@ fn can_fast_reject<N>(mut selector: &CompoundSelector,
 }
 
 fn matches_compound_selector_internal<N>(selector: &CompoundSelector,
-                                            element: &N,
-                                            parent_bf: &Option<Box<BloomFilter>>,
-                                            shareable: &mut bool)
-                                            -> SelectorMatchingResult
-                                            where N: TNode {
+                                         element: &N,
+                                         parent_bf: &Option<Box<BloomFilter>>,
+                                         shareable: &mut bool)
+                                         -> SelectorMatchingResult
+                                         where N: TNode {
     match can_fast_reject(selector, element, parent_bf, shareable) {
         None => {},
         Some(result) => return result,
@@ -573,10 +573,10 @@ pub fn rare_style_affecting_attributes() -> [Atom; 3] {
 /// `main/css/matching.rs`.)
 #[inline]
 pub fn matches_simple_selector<N>(selector: &SimpleSelector,
-                                     element: &N,
-                                     shareable: &mut bool)
-                                     -> bool
-                                     where N: TNode {
+                                  element: &N,
+                                  shareable: &mut bool)
+                                  -> bool
+                                  where N: TNode {
     match *selector {
         SimpleSelector::LocalName(LocalName { ref name, ref lower_name }) => {
             let name = if element.is_html_element_in_html_document() { lower_name } else { name };
@@ -778,12 +778,12 @@ pub fn matches_simple_selector<N>(selector: &SimpleSelector,
 
 #[inline]
 fn matches_generic_nth_child<N>(element: &N,
-                                   a: i32,
-                                   b: i32,
-                                   is_of_type: bool,
-                                   is_from_end: bool)
-                                   -> bool
-                                   where N: TNode {
+                                a: i32,
+                                b: i32,
+                                is_of_type: bool,
+                                is_from_end: bool)
+                                -> bool
+                                where N: TNode {
     let mut node = element.clone();
     // fail if we can't find a parent or if the node is the root element
     // of the document (Cf. Selectors Level 3)

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -71,12 +71,12 @@ impl<T> SelectorMap<T> {
     ///
     /// Extract matching rules as per node's ID, classes, tag name, etc..
     /// Sort the Rules at the end to maintain cascading order.
-    pub fn get_all_matching_rules<'a,N,V>(&self,
+    pub fn get_all_matching_rules<N,V>(&self,
                                           node: &N,
                                           parent_bf: &Option<Box<BloomFilter>>,
                                           matching_rules_list: &mut V,
                                           shareable: &mut bool)
-                                          where N: TNode<'a>,
+                                          where N: TNode,
                                                 V: VecLike<DeclarationBlock<T>> {
         if self.empty {
             return
@@ -132,7 +132,7 @@ impl<T> SelectorMap<T> {
         }
     }
 
-    fn get_matching_rules_from_hash<'a,N,V>(node: &N,
+    fn get_matching_rules_from_hash<N,V>(node: &N,
                                             parent_bf: &Option<Box<BloomFilter>>,
                                             hash: &HashMap<Atom,
                                                            Vec<Rule<T>>,
@@ -140,7 +140,7 @@ impl<T> SelectorMap<T> {
                                             key: &Atom,
                                             matching_rules: &mut V,
                                             shareable: &mut bool)
-                                            where N: TNode<'a>,
+                                            where N: TNode,
                                                   V: VecLike<DeclarationBlock<T>> {
         match hash.get(key) {
             Some(rules) => {
@@ -155,12 +155,12 @@ impl<T> SelectorMap<T> {
     }
 
     /// Adds rules in `rules` that match `node` to the `matching_rules` list.
-    fn get_matching_rules<'a,N,V>(node: &N,
+    fn get_matching_rules<N,V>(node: &N,
                                   parent_bf: &Option<Box<BloomFilter>>,
                                   rules: &[Rule<T>],
                                   matching_rules: &mut V,
                                   shareable: &mut bool)
-                                  where N: TNode<'a>,
+                                  where N: TNode,
                                         V: VecLike<DeclarationBlock<T>> {
         for rule in rules.iter() {
             if matches_compound_selector(&*rule.selector, node, parent_bf, shareable) {
@@ -300,11 +300,11 @@ impl<T> DeclarationBlock<T> {
     }
 }
 
-pub fn matches<'a,N>(selector_list: &Vec<Selector>,
+pub fn matches<N>(selector_list: &Vec<Selector>,
                      element: &N,
                      parent_bf: &Option<Box<BloomFilter>>)
                      -> bool
-                     where N: TNode<'a> {
+                     where N: TNode {
     selector_list.iter().any(|selector| {
         selector.pseudo_element.is_none() &&
         matches_compound_selector(&*selector.compound_selectors, element, parent_bf, &mut false)
@@ -317,12 +317,12 @@ pub fn matches<'a,N>(selector_list: &Vec<Selector>,
 /// `shareable` to false unless you are willing to update the style sharing logic. Otherwise things
 /// will almost certainly break as nodes will start mistakenly sharing styles. (See the code in
 /// `main/css/matching.rs`.)
-fn matches_compound_selector<'a,N>(selector: &CompoundSelector,
+fn matches_compound_selector<N>(selector: &CompoundSelector,
                                    element: &N,
                                    parent_bf: &Option<Box<BloomFilter>>,
                                    shareable: &mut bool)
                                    -> bool
-                                   where N: TNode<'a> {
+                                   where N: TNode {
     match matches_compound_selector_internal(selector, element, parent_bf, shareable) {
         SelectorMatchingResult::Matched => true,
         _ => false
@@ -382,12 +382,12 @@ enum SelectorMatchingResult {
 /// Quickly figures out whether or not the compound selector is worth doing more
 /// work on. If the simple selectors don't match, or there's a child selector
 /// that does not appear in the bloom parent bloom filter, we can exit early.
-fn can_fast_reject<'a,N>(mut selector: &CompoundSelector,
+fn can_fast_reject<N>(mut selector: &CompoundSelector,
                          element: &N,
                          parent_bf: &Option<Box<BloomFilter>>,
                          shareable: &mut bool)
                          -> Option<SelectorMatchingResult>
-                         where N: TNode<'a> {
+                         where N: TNode {
     if !selector.simple_selectors.iter().all(|simple_selector| {
       matches_simple_selector(simple_selector, element, shareable) }) {
         return Some(SelectorMatchingResult::NotMatchedAndRestartFromClosestLaterSibling);
@@ -443,12 +443,12 @@ fn can_fast_reject<'a,N>(mut selector: &CompoundSelector,
     return None;
 }
 
-fn matches_compound_selector_internal<'a,N>(selector: &CompoundSelector,
+fn matches_compound_selector_internal<N>(selector: &CompoundSelector,
                                             element: &N,
                                             parent_bf: &Option<Box<BloomFilter>>,
                                             shareable: &mut bool)
                                             -> SelectorMatchingResult
-                                            where N: TNode<'a> {
+                                            where N: TNode {
     match can_fast_reject(selector, element, parent_bf, shareable) {
         None => {},
         Some(result) => return result,
@@ -572,11 +572,11 @@ pub fn rare_style_affecting_attributes() -> [Atom; 3] {
 /// will almost certainly break as nodes will start mistakenly sharing styles. (See the code in
 /// `main/css/matching.rs`.)
 #[inline]
-pub fn matches_simple_selector<'a,N>(selector: &SimpleSelector,
+pub fn matches_simple_selector<N>(selector: &SimpleSelector,
                                      element: &N,
                                      shareable: &mut bool)
                                      -> bool
-                                     where N: TNode<'a> {
+                                     where N: TNode {
     match *selector {
         SimpleSelector::LocalName(LocalName { ref name, ref lower_name }) => {
             let name = if element.is_html_element_in_html_document() { lower_name } else { name };
@@ -777,13 +777,13 @@ pub fn matches_simple_selector<'a,N>(selector: &SimpleSelector,
 }
 
 #[inline]
-fn matches_generic_nth_child<'a,N>(element: &N,
+fn matches_generic_nth_child<N>(element: &N,
                                    a: i32,
                                    b: i32,
                                    is_of_type: bool,
                                    is_from_end: bool)
                                    -> bool
-                                   where N: TNode<'a> {
+                                   where N: TNode {
     let mut node = element.clone();
     // fail if we can't find a parent or if the node is the root element
     // of the document (Cf. Selectors Level 3)
@@ -831,7 +831,7 @@ fn matches_generic_nth_child<'a,N>(element: &N,
 }
 
 #[inline]
-fn matches_root<'a,N>(element: &N) -> bool where N: TNode<'a> {
+fn matches_root<N>(element: &N) -> bool where N: TNode {
     match element.parent_node() {
         Some(parent) => parent.is_document(),
         None => false
@@ -839,7 +839,7 @@ fn matches_root<'a,N>(element: &N) -> bool where N: TNode<'a> {
 }
 
 #[inline]
-fn matches_first_child<'a,N>(element: &N) -> bool where N: TNode<'a> {
+fn matches_first_child<N>(element: &N) -> bool where N: TNode {
     let mut node = element.clone();
     loop {
         match node.prev_sibling() {
@@ -861,7 +861,7 @@ fn matches_first_child<'a,N>(element: &N) -> bool where N: TNode<'a> {
 }
 
 #[inline]
-fn matches_last_child<'a,N>(element: &N) -> bool where N: TNode<'a> {
+fn matches_last_child<N>(element: &N) -> bool where N: TNode {
     let mut node = element.clone();
     loop {
         match node.next_sibling() {

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -766,7 +766,7 @@ pub fn matches_simple_selector<N>(selector: &SimpleSelector,
         SimpleSelector::ServoNonzeroBorder => {
             *shareable = false;
             let elem = element.as_element();
-            elem.has_nonzero_border()
+            elem.has_servo_nonzero_border()
         }
 
         SimpleSelector::Negation(ref negated) => {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -9,55 +9,55 @@ use parser::AttrSelector;
 use string_cache::{Atom, Namespace};
 
 
-pub trait TNode<'a>: Clone + Copy {
-    type Element: TElement<'a>;
+pub trait TNode: Clone {
+    type Element: TElement;
 
-    fn parent_node(self) -> Option<Self>;
-    fn first_child(self) -> Option<Self>;
-    fn last_child(self) -> Option<Self>;
-    fn prev_sibling(self) -> Option<Self>;
-    fn next_sibling(self) -> Option<Self>;
-    fn is_document(self) -> bool;
-    fn is_element(self) -> bool;
-    fn as_element(self) -> Self::Element;
-    fn match_attr<F>(self, attr: &AttrSelector, test: F) -> bool where F: Fn(&str) -> bool;
-    fn is_html_element_in_html_document(self) -> bool;
+    fn parent_node(&self) -> Option<Self>;
+    fn first_child(&self) -> Option<Self>;
+    fn last_child(&self) -> Option<Self>;
+    fn prev_sibling(&self) -> Option<Self>;
+    fn next_sibling(&self) -> Option<Self>;
+    fn is_document(&self) -> bool;
+    fn is_element(&self) -> bool;
+    fn as_element(&self) -> Self::Element;
+    fn match_attr<F>(&self, attr: &AttrSelector, test: F) -> bool where F: Fn(&str) -> bool;
+    fn is_html_element_in_html_document(&self) -> bool;
 
-    fn has_changed(self) -> bool;
-    unsafe fn set_changed(self, value: bool);
+    fn has_changed(&self) -> bool;
+    unsafe fn set_changed(&self, value: bool);
 
-    fn is_dirty(self) -> bool;
-    unsafe fn set_dirty(self, value: bool);
+    fn is_dirty(&self) -> bool;
+    unsafe fn set_dirty(&self, value: bool);
 
-    fn has_dirty_siblings(self) -> bool;
-    unsafe fn set_dirty_siblings(self, value: bool);
+    fn has_dirty_siblings(&self) -> bool;
+    unsafe fn set_dirty_siblings(&self, value: bool);
 
-    fn has_dirty_descendants(self) -> bool;
-    unsafe fn set_dirty_descendants(self, value: bool);
+    fn has_dirty_descendants(&self) -> bool;
+    unsafe fn set_dirty_descendants(&self, value: bool);
 }
 
-pub trait TElement<'a>: Copy {
-    fn get_local_name(self) -> &'a Atom;
-    fn get_namespace(self) -> &'a Namespace;
-    fn get_hover_state(self) -> bool;
-    fn get_focus_state(self) -> bool;
-    fn get_id(self) -> Option<Atom>;
-    fn get_disabled_state(self) -> bool;
-    fn get_enabled_state(self) -> bool;
-    fn get_checked_state(self) -> bool;
-    fn get_indeterminate_state(self) -> bool;
-    fn has_class(self, name: &Atom) -> bool;
-    fn has_nonzero_border(self) -> bool;
+pub trait TElement {
+    fn get_local_name<'a>(&'a self) -> &'a Atom;
+    fn get_namespace<'a>(&'a self) -> &'a Namespace;
+    fn get_hover_state(&self) -> bool;
+    fn get_focus_state(&self) -> bool;
+    fn get_id(&self) -> Option<Atom>;
+    fn get_disabled_state(&self) -> bool;
+    fn get_enabled_state(&self) -> bool;
+    fn get_checked_state(&self) -> bool;
+    fn get_indeterminate_state(&self) -> bool;
+    fn has_class(&self, name: &Atom) -> bool;
+    fn has_nonzero_border(&self) -> bool;
     /// Returns whether this element matches either `:link` or `:visited`.
-    fn is_link(self) -> bool;
+    fn is_link(&self) -> bool;
     /// Returns whether this element matches `:visited`.
-    fn is_visited_link(self) -> bool;
+    fn is_visited_link(&self) -> bool;
     /// Returns whether this element matches `:link`.
-    fn is_unvisited_link(self) -> bool;
+    fn is_unvisited_link(&self) -> bool;
 
     // Ordinarily I wouldn't use callbacks like this, but the alternative is
     // really messy, since there is a `JSRef` and a `RefCell` involved. Maybe
     // in the future when we have associated types and/or a more convenient
     // JS GC story... --pcwalton
-    fn each_class<F>(self, callback: F) where F: FnMut(&Atom);
+    fn each_class<F>(&self, callback: F) where F: FnMut(&Atom);
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -22,18 +22,6 @@ pub trait TNode: Clone {
     fn as_element(&self) -> Self::Element;
     fn match_attr<F>(&self, attr: &AttrSelector, test: F) -> bool where F: Fn(&str) -> bool;
     fn is_html_element_in_html_document(&self) -> bool;
-
-    fn has_changed(&self) -> bool;
-    unsafe fn set_changed(&self, value: bool);
-
-    fn is_dirty(&self) -> bool;
-    unsafe fn set_dirty(&self, value: bool);
-
-    fn has_dirty_siblings(&self) -> bool;
-    unsafe fn set_dirty_siblings(&self, value: bool);
-
-    fn has_dirty_descendants(&self) -> bool;
-    unsafe fn set_dirty_descendants(&self, value: bool);
 }
 
 pub trait TElement {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -35,13 +35,28 @@ pub trait TElement {
     fn get_checked_state(&self) -> bool;
     fn get_indeterminate_state(&self) -> bool;
     fn has_class(&self, name: &Atom) -> bool;
-    fn has_nonzero_border(&self) -> bool;
-    /// Returns whether this element matches either `:link` or `:visited`.
+
+
+    /// Returns whether this element matches `:-servo-nonzero-border`,
+    /// which is only parsed when ParserContext::in_user_agent_stylesheet is true.
+    /// It is an implementation detail of Servo for "only if border is not equivalent to zero":
+    /// https://html.spec.whatwg.org/multipage/#magic-border-selector
+    ///
+    /// Feel free to ignore this outside of Servo and keep the default implement, always `false`.
+    fn has_servo_nonzero_border(&self) -> bool { false }
+
+    /// Returns whether this element matches `:any-link`.
     fn is_link(&self) -> bool;
+
     /// Returns whether this element matches `:visited`.
-    fn is_visited_link(&self) -> bool;
-    /// Returns whether this element matches `:link`.
-    fn is_unvisited_link(&self) -> bool;
+    ///
+    /// Defaults to `false`: when browsing history is not recorded, no links are ever "visited".
+    fn is_visited_link(&self) -> bool { false }
+
+    /// Returns whether this element matches `:link` (which is exclusive with `:visited`).
+    ///
+    /// Defaults to `is_link()`: when browsing history is not recorded, all links are "unvisited".
+    fn is_unvisited_link(&self) -> bool { self.is_link() }
 
     // Ordinarily I wouldn't use callbacks like this, but the alternative is
     // really messy, since there is a `JSRef` and a `RefCell` involved. Maybe


### PR DESCRIPTION
This enables reference-counted nodes in Kuchiki.

This is more indirection than necessary in Servo (e.g `self: &JSRef<'a, Node>` instead of `JSRef<'a, Node>`, which is itself a pointer) but hopefully this gets optimized away?
