### PR TITLE
Use an introspective sort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,7 @@ smallvec = "0.1"
 fnv = "1.0"
 string_cache = "0.1"
 string_cache_plugin = "0.1"
-
-[dependencies.introsort]
-git = "https://github.com/notriddle/rust-introsort"
+quickersort = "1.0.0"
 
 [dev-dependencies]
 rand = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,14 @@ license = "MPL-2.0"
 [dependencies]
 bitflags = "0.3"
 matches = "0.1"
-quicksort = "1.0"
 cssparser = "0.3"
 smallvec = "0.1"
 fnv = "1.0"
 string_cache = "0.1"
 string_cache_plugin = "0.1"
+
+[dependencies.introsort]
+git = "https://github.com/notriddle/rust-introsort"
 
 [dev-dependencies]
 rand = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 #[macro_use] extern crate matches;
 #[cfg(test)] extern crate rand;
 extern crate string_cache;
-extern crate introsort;
+extern crate quickersort;
 extern crate smallvec;
 extern crate fnv;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 #[macro_use] extern crate matches;
 #[cfg(test)] extern crate rand;
 extern crate string_cache;
-extern crate quicksort;
+extern crate introsort;
 extern crate smallvec;
 extern crate fnv;
 

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use bloom::BloomFilter;
 use smallvec::VecLike;
-use introsort::sort_by;
+use quickersort::sort_by;
 use string_cache::Atom;
 
 use fnv::FnvHasher;

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use bloom::BloomFilter;
 use smallvec::VecLike;
-use quicksort::quicksort_by;
+use introsort::sort_by;
 use string_cache::Atom;
 
 use fnv::FnvHasher;
@@ -121,7 +121,7 @@ impl<T> SelectorMap<T> {
                                         shareable);
 
         // Sort only the rules we just added.
-        quicksort_by(&mut matching_rules_list[init_len..], compare);
+        sort_by(&mut matching_rules_list[init_len..], &compare);
 
         fn compare<T>(a: &DeclarationBlock<T>, b: &DeclarationBlock<T>) -> Ordering {
             (a.specificity, a.source_order).cmp(&(b.specificity, b.source_order))


### PR DESCRIPTION
Rust-selectors currently uses a naive recursive quicksort. This algorithm performs O(n^2) comparisons when the list is already sorted, and, worse, creates O(n^2) stack frames, as seen in servo/servo#6824.

Let's be smarter.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-selectors/43)

<!-- Reviewable:end -->
