### PR TITLE
Revert "Add hooks for :target pseudo-selector"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "selectors"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 documentation = "http://doc.servo.org/selectors/"
 

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -692,11 +692,6 @@ pub fn matches_simple_selector<E>(selector: &SimpleSelector,
             *shareable = false;
             element.get_indeterminate_state()
         }
-        // https://html.spec.whatwg.org/multipage/scripting.html#selector-target
-        SimpleSelector::Target => {
-            *shareable = false;
-            element.get_target_state()
-        }
         SimpleSelector::FirstChild => {
             *shareable = false;
             matches_first_child(element)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -100,7 +100,6 @@ pub enum SimpleSelector {
     LastOfType,
     OnlyOfType,
     ServoNonzeroBorder,
-    Target,
     // ...
 }
 
@@ -186,7 +185,6 @@ fn compute_specificity(mut selector: &CompoundSelector,
                 &SimpleSelector::Empty |
                 &SimpleSelector::Checked |
                 &SimpleSelector::Indeterminate |
-                &SimpleSelector::Target |
                 &SimpleSelector::NthChild(..) |
                 &SimpleSelector::NthLastChild(..) |
                 &SimpleSelector::NthOfType(..) |
@@ -635,7 +633,6 @@ fn parse_simple_pseudo_class(context: &ParserContext, name: &str) -> Result<Simp
         "first-of-type" => Ok(SimpleSelector::FirstOfType),
         "last-of-type"  => Ok(SimpleSelector::LastOfType),
         "only-of-type"  => Ok(SimpleSelector::OnlyOfType),
-        "target"  => Ok(SimpleSelector::Target),
         "-servo-nonzero-border" => {
             if context.in_user_agent_stylesheet {
                 Ok(SimpleSelector::ServoNonzeroBorder)

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -35,7 +35,6 @@ pub trait Element: Sized {
     fn get_enabled_state(&self) -> bool;
     fn get_checked_state(&self) -> bool;
     fn get_indeterminate_state(&self) -> bool;
-    fn get_target_state(&self) -> bool;
     fn has_class(&self, name: &Atom) -> bool;
     fn match_attr<F>(&self, attr: &AttrSelector, test: F) -> bool where F: Fn(&str) -> bool;
 


### PR DESCRIPTION
This reverts commit 11b01919b8e160c5d93c0bb496fea5062307f0dc, which breaks servo.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-selectors/54)

<!-- Reviewable:end -->
