### PR TITLE
Move back to boolean methods for event states

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "selectors"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 documentation = "http://doc.servo.org/selectors/"
 

--- a/src/event_state.rs
+++ b/src/event_state.rs
@@ -2,29 +2,46 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-bitflags! {
-    #[doc = "Element Event States."]
-    flags EventState: u16 {
+#[macro_export]
+macro_rules! event_based_pseudo_classes {
+    ($macro_name: ident) => { $macro_name! {
         #[doc = "The mouse is down on this element. \
                  (https://html.spec.whatwg.org/multipage/#selector-active). \
                  FIXME(#7333): set/unset this when appropriate"]
-        const IN_ACTIVE_STATE = 0x01,
+        event "active" => Active / IN_ACTIVE_STATE = 0x01,
         #[doc = "This element has focus.
                  https://html.spec.whatwg.org/multipage/scripting.html#selector-focus"]
-        const IN_FOCUS_STATE = 0x02,
+        event "focus" => Focus / IN_FOCUS_STATE = 0x02,
         #[doc = "The mouse is hovering over this element. \
                  https://html.spec.whatwg.org/multipage/scripting.html#selector-hover"]
-        const IN_HOVER_STATE = 0x04,
+        event "hover" => Hover / IN_HOVER_STATE = 0x04,
         #[doc = "Content is enabled (and can be disabled). \
                  http://www.whatwg.org/html/#selector-enabled"]
-        const IN_ENABLED_STATE = 0x08,
+        event "enabled" => Enabled / IN_ENABLED_STATE = 0x08,
         #[doc = "Content is disabled. \
                  http://www.whatwg.org/html/#selector-disabled"]
-        const IN_DISABLED_STATE = 0x10,
+        event "disabled" => Disabled / IN_DISABLED_STATE = 0x10,
         #[doc = "Content is checked. \
                  https://html.spec.whatwg.org/multipage/scripting.html#selector-checked"]
-        const IN_CHECKED_STATE = 0x20,
+        event "checked" => Checked / IN_CHECKED_STATE = 0x20,
         #[doc = "https://html.spec.whatwg.org/multipage/scripting.html#selector-indeterminate"]
-        const IN_INDETERMINATE_STATE = 0x40,
+        event "indeterminate" => Indeterminate / IN_INDETERMINATE_STATE = 0x40,
+    }}
+}
+
+macro_rules! event_states_bitflag {
+    ($(
+        $(#[$Flag_attr: meta])*
+        event $css: expr => $variant: ident / $flag: ident = $value: expr,
+    )+) => {
+        bitflags! {
+            #[doc = "Element Event States."]
+            flags EventState: u16 {
+                $($(#[$Flag_attr])* const $flag = $value,)+
+            }
+        }
     }
 }
+
+
+event_based_pseudo_classes!(event_states_bitflag);

--- a/src/event_state.rs
+++ b/src/event_state.rs
@@ -8,31 +8,32 @@ macro_rules! event_based_pseudo_classes {
         #[doc = "The mouse is down on this element. \
                  (https://html.spec.whatwg.org/multipage/#selector-active). \
                  FIXME(#7333): set/unset this when appropriate"]
-        event "active" => Active / IN_ACTIVE_STATE = 0x01,
+        event "active" => Active / get_active_state / IN_ACTIVE_STATE = 0x01,
         #[doc = "This element has focus.
                  https://html.spec.whatwg.org/multipage/scripting.html#selector-focus"]
-        event "focus" => Focus / IN_FOCUS_STATE = 0x02,
+        event "focus" => Focus / get_focus_state / IN_FOCUS_STATE = 0x02,
         #[doc = "The mouse is hovering over this element. \
                  https://html.spec.whatwg.org/multipage/scripting.html#selector-hover"]
-        event "hover" => Hover / IN_HOVER_STATE = 0x04,
+        event "hover" => Hover / get_hover_state / IN_HOVER_STATE = 0x04,
         #[doc = "Content is enabled (and can be disabled). \
                  http://www.whatwg.org/html/#selector-enabled"]
-        event "enabled" => Enabled / IN_ENABLED_STATE = 0x08,
+        event "enabled" => Enabled / get_enabled_state / IN_ENABLED_STATE = 0x08,
         #[doc = "Content is disabled. \
                  http://www.whatwg.org/html/#selector-disabled"]
-        event "disabled" => Disabled / IN_DISABLED_STATE = 0x10,
+        event "disabled" => Disabled / get_disabled_state / IN_DISABLED_STATE = 0x10,
         #[doc = "Content is checked. \
                  https://html.spec.whatwg.org/multipage/scripting.html#selector-checked"]
-        event "checked" => Checked / IN_CHECKED_STATE = 0x20,
+        event "checked" => Checked / get_checked_state / IN_CHECKED_STATE = 0x20,
         #[doc = "https://html.spec.whatwg.org/multipage/scripting.html#selector-indeterminate"]
-        event "indeterminate" => Indeterminate / IN_INDETERMINATE_STATE = 0x40,
+        event "indeterminate" => Indeterminate / get_intermediate_state / IN_INDETERMINATE_STATE = 0x40,
     }}
 }
 
 macro_rules! event_states_bitflag {
     ($(
         $(#[$Flag_attr: meta])*
-        event $css: expr => $variant: ident / $flag: ident = $value: expr,
+        event $css: expr => $variant: ident / $method: ident /
+        $flag: ident = $value: expr,
     )+) => {
         bitflags! {
             #[doc = "Element Event States."]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ extern crate smallvec;
 extern crate fnv;
 
 pub mod bloom;
-#[macro_use] pub mod event_state;
+#[macro_use] pub mod states;
 pub mod matching;
 pub mod parser;
 mod tree;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ extern crate smallvec;
 extern crate fnv;
 
 pub mod bloom;
-pub mod event_state;
+#[macro_use] pub mod event_state;
 pub mod matching;
 pub mod parser;
 mod tree;

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -5,7 +5,8 @@
 macro_rules! module {
     ($(
         $(#[$Flag_attr: meta])*
-        event $css: expr => $variant: ident / $flag: ident = $value: expr,
+        event $css: expr => $variant: ident / $method: ident /
+        $flag: ident = $value: expr,
     )+) => {
 
 use std::ascii::AsciiExt;
@@ -13,7 +14,6 @@ use std::cmp::Ordering;
 use std::sync::Arc;
 
 use bloom::BloomFilter;
-use event_state::*;
 use smallvec::VecLike;
 use quickersort::sort_by;
 use string_cache::Atom;
@@ -667,7 +667,7 @@ pub fn matches_simple_selector<E>(selector: &SimpleSelector,
         $(
             SimpleSelector::$variant => {
                 *shareable = false;
-                element.get_state().contains($flag)
+                element.$method()
             },
         )+
         SimpleSelector::FirstChild => {

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -2,6 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+macro_rules! module {
+    ($(
+        $(#[$Flag_attr: meta])*
+        event $css: expr => $variant: ident / $flag: ident = $value: expr,
+    )+) => {
+
 use std::ascii::AsciiExt;
 use std::cmp::Ordering;
 use std::sync::Arc;
@@ -658,41 +664,12 @@ pub fn matches_simple_selector<E>(selector: &SimpleSelector,
         SimpleSelector::Visited => {
             element.is_visited_link()
         }
-        // https://html.spec.whatwg.org/multipage/scripting.html#selector-hover
-        SimpleSelector::Hover => {
-            *shareable = false;
-            element.get_state().contains(IN_HOVER_STATE)
-        },
-        // https://html.spec.whatwg.org/multipage/scripting.html#selector-focus
-        SimpleSelector::Focus => {
-            *shareable = false;
-            element.get_state().contains(IN_FOCUS_STATE)
-        },
-        // https://html.spec.whatwg.org/multipage/scripting.html#selector-active
-        SimpleSelector::Active => {
-            *shareable = false;
-            element.get_state().contains(IN_ACTIVE_STATE)
-        },
-        // http://www.whatwg.org/html/#selector-disabled
-        SimpleSelector::Disabled => {
-            *shareable = false;
-            element.get_state().contains(IN_DISABLED_STATE)
-        },
-        // http://www.whatwg.org/html/#selector-enabled
-        SimpleSelector::Enabled => {
-            *shareable = false;
-            element.get_state().contains(IN_ENABLED_STATE)
-        },
-        // https://html.spec.whatwg.org/multipage/scripting.html#selector-checked
-        SimpleSelector::Checked => {
-            *shareable = false;
-            element.get_state().contains(IN_CHECKED_STATE)
-        }
-        // https://html.spec.whatwg.org/multipage/scripting.html#selector-indeterminate
-        SimpleSelector::Indeterminate => {
-            *shareable = false;
-            element.get_state().contains(IN_INDETERMINATE_STATE)
-        }
+        $(
+            SimpleSelector::$variant => {
+                *shareable = false;
+                element.get_state().contains($flag)
+            },
+        )+
         SimpleSelector::FirstChild => {
             *shareable = false;
             matches_first_child(element)
@@ -909,3 +886,8 @@ mod tests {
         assert!(selector_map.class_hash.get(&Atom::from_slice("foo")).is_none());
     }
 }
+
+// End of `macro_rules! module`
+    }
+}
+event_based_pseudo_classes!(module);

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -5,7 +5,7 @@
 macro_rules! module {
     ($(
         $(#[$Flag_attr: meta])*
-        event $css: expr => $variant: ident / $method: ident /
+        state $css: expr => $variant: ident / $method: ident /
         $flag: ident = $value: expr,
     )+) => {
 
@@ -890,4 +890,4 @@ mod tests {
 // End of `macro_rules! module`
     }
 }
-event_based_pseudo_classes!(module);
+state_pseudo_classes!(module);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,8 @@
 macro_rules! module {
     ($(
         $(#[$Flag_attr: meta])*
-        event $css: expr => $variant: ident / $flag: ident = $value: expr,
+        event $css: expr => $variant: ident / $method: ident /
+        $flag: ident = $value: expr,
     )+) => {
 
 use std::ascii::AsciiExt;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,6 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+macro_rules! module {
+    ($(
+        $(#[$Flag_attr: meta])*
+        event $css: expr => $variant: ident / $flag: ident = $value: expr,
+    )+) => {
+
 use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::cmp;
@@ -82,13 +88,9 @@ pub enum SimpleSelector {
     AnyLink,
     Link,
     Visited,
-    Hover,
-    Focus,
-    Active,
-    Disabled,
-    Enabled,
-    Checked,
-    Indeterminate,
+
+    $( $variant, )+
+
     FirstChild, LastChild, OnlyChild,
     Root,
     Empty,
@@ -177,14 +179,13 @@ fn compute_specificity(mut selector: &CompoundSelector,
                 &SimpleSelector::AttrSubstringMatch(..) |
                 &SimpleSelector::AttrSuffixMatch(..) |
                 &SimpleSelector::AnyLink | &SimpleSelector::Link |
-                &SimpleSelector::Visited | &SimpleSelector::Hover |
-                &SimpleSelector::Focus | &SimpleSelector::Active |
-                &SimpleSelector::Disabled | &SimpleSelector::Enabled |
+                &SimpleSelector::Visited |
+
+                $( &SimpleSelector::$variant | )+
+
                 &SimpleSelector::FirstChild | &SimpleSelector::LastChild |
                 &SimpleSelector::OnlyChild | &SimpleSelector::Root |
                 &SimpleSelector::Empty |
-                &SimpleSelector::Checked |
-                &SimpleSelector::Indeterminate |
                 &SimpleSelector::NthChild(..) |
                 &SimpleSelector::NthLastChild(..) |
                 &SimpleSelector::NthOfType(..) |
@@ -618,13 +619,9 @@ fn parse_simple_pseudo_class(context: &ParserContext, name: &str) -> Result<Simp
         "any-link" => Ok(SimpleSelector::AnyLink),
         "link" => Ok(SimpleSelector::Link),
         "visited" => Ok(SimpleSelector::Visited),
-        "hover" => Ok(SimpleSelector::Hover),
-        "focus" => Ok(SimpleSelector::Focus),
-        "active" => Ok(SimpleSelector::Active),
-        "disabled" => Ok(SimpleSelector::Disabled),
-        "enabled" => Ok(SimpleSelector::Enabled),
-        "checked" => Ok(SimpleSelector::Checked),
-        "indeterminate" => Ok(SimpleSelector::Indeterminate),
+
+        $( $css => Ok(SimpleSelector::$variant), )+
+
         "first-child" => Ok(SimpleSelector::FirstChild),
         "last-child"  => Ok(SimpleSelector::LastChild),
         "only-child"  => Ok(SimpleSelector::OnlyChild),
@@ -830,3 +827,8 @@ mod tests {
         }]))
     }
 }
+
+// End of `macro_rules! module`
+    }
+}
+event_based_pseudo_classes!(module);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@
 macro_rules! module {
     ($(
         $(#[$Flag_attr: meta])*
-        event $css: expr => $variant: ident / $method: ident /
+        state $css: expr => $variant: ident / $method: ident /
         $flag: ident = $value: expr,
     )+) => {
 
@@ -832,4 +832,4 @@ mod tests {
 // End of `macro_rules! module`
     }
 }
-event_based_pseudo_classes!(module);
+state_pseudo_classes!(module);

--- a/src/states.rs
+++ b/src/states.rs
@@ -3,41 +3,41 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #[macro_export]
-macro_rules! event_based_pseudo_classes {
+macro_rules! state_pseudo_classes {
     ($macro_name: ident) => { $macro_name! {
         #[doc = "The mouse is down on this element. \
                  (https://html.spec.whatwg.org/multipage/#selector-active). \
                  FIXME(#7333): set/unset this when appropriate"]
-        event "active" => Active / get_active_state / IN_ACTIVE_STATE = 0x01,
+        state "active" => Active / get_active_state / IN_ACTIVE_STATE = 0x01,
         #[doc = "This element has focus.
                  https://html.spec.whatwg.org/multipage/scripting.html#selector-focus"]
-        event "focus" => Focus / get_focus_state / IN_FOCUS_STATE = 0x02,
+        state "focus" => Focus / get_focus_state / IN_FOCUS_STATE = 0x02,
         #[doc = "The mouse is hovering over this element. \
                  https://html.spec.whatwg.org/multipage/scripting.html#selector-hover"]
-        event "hover" => Hover / get_hover_state / IN_HOVER_STATE = 0x04,
+        state "hover" => Hover / get_hover_state / IN_HOVER_STATE = 0x04,
         #[doc = "Content is enabled (and can be disabled). \
                  http://www.whatwg.org/html/#selector-enabled"]
-        event "enabled" => Enabled / get_enabled_state / IN_ENABLED_STATE = 0x08,
+        state "enabled" => Enabled / get_enabled_state / IN_ENABLED_STATE = 0x08,
         #[doc = "Content is disabled. \
                  http://www.whatwg.org/html/#selector-disabled"]
-        event "disabled" => Disabled / get_disabled_state / IN_DISABLED_STATE = 0x10,
+        state "disabled" => Disabled / get_disabled_state / IN_DISABLED_STATE = 0x10,
         #[doc = "Content is checked. \
                  https://html.spec.whatwg.org/multipage/scripting.html#selector-checked"]
-        event "checked" => Checked / get_checked_state / IN_CHECKED_STATE = 0x20,
+        state "checked" => Checked / get_checked_state / IN_CHECKED_STATE = 0x20,
         #[doc = "https://html.spec.whatwg.org/multipage/scripting.html#selector-indeterminate"]
-        event "indeterminate" => Indeterminate / get_intermediate_state / IN_INDETERMINATE_STATE = 0x40,
+        state "indeterminate" => Indeterminate / get_intermediate_state / IN_INDETERMINATE_STATE = 0x40,
     }}
 }
 
-macro_rules! event_states_bitflag {
+macro_rules! states_bitflag {
     ($(
         $(#[$Flag_attr: meta])*
-        event $css: expr => $variant: ident / $method: ident /
+        state $css: expr => $variant: ident / $method: ident /
         $flag: ident = $value: expr,
     )+) => {
         bitflags! {
-            #[doc = "Element Event States."]
-            flags EventState: u16 {
+            #[doc = "Event-based element states."]
+            flags ElementState: u16 {
                 $($(#[$Flag_attr])* const $flag = $value,)+
             }
         }
@@ -45,4 +45,4 @@ macro_rules! event_states_bitflag {
 }
 
 
-event_based_pseudo_classes!(event_states_bitflag);
+state_pseudo_classes!(states_bitflag);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -8,7 +8,7 @@
 macro_rules! module {
     ($(
         $(#[$Flag_attr: meta])*
-        event $css: expr => $variant: ident / $method: ident /
+        state $css: expr => $variant: ident / $method: ident /
         $flag: ident = $value: expr,
     )+) => {
 
@@ -84,4 +84,4 @@ pub trait Element: Sized {
 // End of `macro_rules! module`
     }
 }
-event_based_pseudo_classes!(module);
+state_pseudo_classes!(module);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -5,10 +5,15 @@
 //! Traits that nodes must implement. Breaks the otherwise-cyclic dependency between layout and
 //! style.
 
-use event_state::EventState;
+macro_rules! module {
+    ($(
+        $(#[$Flag_attr: meta])*
+        event $css: expr => $variant: ident / $method: ident /
+        $flag: ident = $value: expr,
+    )+) => {
+
 use parser::AttrSelector;
 use string_cache::{Atom, Namespace};
-
 
 pub trait Element: Sized {
     fn parent_element(&self) -> Option<Self>;
@@ -28,7 +33,9 @@ pub trait Element: Sized {
     fn is_html_element_in_html_document(&self) -> bool;
     fn get_local_name<'a>(&'a self) -> &'a Atom;
     fn get_namespace<'a>(&'a self) -> &'a Namespace;
-    fn get_state(&self) -> EventState;
+
+    $( fn $method(&self) -> bool; )+
+
     fn get_id(&self) -> Option<Atom>;
     fn has_class(&self, name: &Atom) -> bool;
     fn match_attr<F>(&self, attr: &AttrSelector, test: F) -> bool where F: Fn(&str) -> bool;
@@ -73,3 +80,8 @@ pub trait Element: Sized {
     // JS GC story... --pcwalton
     fn each_class<F>(&self, callback: F) where F: FnMut(&Atom);
 }
+
+// End of `macro_rules! module`
+    }
+}
+event_based_pseudo_classes!(module);


### PR DESCRIPTION
The first commit uses `macro_rules!` to de-duplicate some definitions, but should not change any API or behavior. The `event_based_pseudo_classes!` macro is exported.

The second commit reverts changes to the `Element` trait made in #55, but keeps the `EventState` bit field definition. If users like Servo store `EventState` on elements directly, they have to do the `.contains()` calls themselves. But duplication here can be removed by using `event_based_pseudo_classes!` for the trait impl the same way it is used for the trait definition.

@bholley, does this sound acceptable, to implement style hints?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-selectors/56)

<!-- Reviewable:end -->
