### PR TITLE
Make matches_compound_selector public

### DIFF
--- a/src/matching.rs
+++ b/src/matching.rs
@@ -309,12 +309,12 @@ pub fn matches<E>(selector_list: &Vec<Selector>,
 /// `shareable` to false unless you are willing to update the style sharing logic. Otherwise things
 /// will almost certainly break as elements will start mistakenly sharing styles. (See the code in
 /// `main/css/matching.rs`.)
-fn matches_compound_selector<E>(selector: &CompoundSelector,
-                                element: &E,
-                                parent_bf: Option<&BloomFilter>,
-                                shareable: &mut bool)
-                                -> bool
-                                where E: Element {
+pub fn matches_compound_selector<E>(selector: &CompoundSelector,
+                                    element: &E,
+                                    parent_bf: Option<&BloomFilter>,
+                                    shareable: &mut bool)
+                                    -> bool
+                                    where E: Element {
     match matches_compound_selector_internal(selector, element, parent_bf, shareable) {
         SelectorMatchingResult::Matched => true,
         _ => false


### PR DESCRIPTION
We need to invoke this on partial selectors for restyle hints.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-selectors/58)

<!-- Reviewable:end -->
