### PR TITLE
Remove now default 'sudo: false'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: rust
 rust:
     - nightly


### PR DESCRIPTION
'sudo: false' is now the default setting for Travis CI

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-selectors/70)

<!-- Reviewable:end -->
