### PR TITLE
Upgrade to rustc 1.9.0-nightly (6d215fe04 2016-03-14)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "selectors"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Simon Sapin <simon.sapin@exyr.org>", "Alan Jeffrey <ajeffrey@mozilla.com>"]
 documentation = "http://doc.servo.org/selectors/"
 
@@ -23,15 +23,8 @@ smallvec = "0.1"
 fnv = "1.0"
 string_cache = "0.2"
 quickersort = "1.0.0"
-
-[dependencies.heapsize]
-version = ">=0.1.1, <0.4"
-features = [ "unstable" ]
-optional = true
-
-[dependencies.heapsize_plugin]
-version = "0.1.0"
-optional = true
+heapsize = {version = ">=0.1.1, <0.4", features = ["unstable"], optional = true}
+heapsize_plugin = {version = "0.1.0", optional = true}
 
 [dev-dependencies]
 rand = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![cfg_attr(feature = "unstable", feature(plugin, hashmap_hasher, custom_derive))]
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 #![cfg_attr(feature = "heap_size", feature(plugin, custom_derive))]
 #![cfg_attr(feature = "heap_size", plugin(heapsize_plugin))]
@@ -24,27 +23,4 @@ mod tree;
 
 pub use tree::Element;
 
-
-#[cfg(feature = "unstable")]
-mod hash_map {
-    use std::collections::hash_state::DefaultState;
-    use std::hash::Hash;
-
-    pub type HashMap<K, V> = ::std::collections::HashMap<K, V, DefaultState<::fnv::FnvHasher>>;
-
-    pub fn new<K, V>() -> HashMap<K, V> where K: Hash + Eq {
-        ::std::collections::HashMap::with_hash_state(Default::default())
-    }
-}
-
-#[cfg(not(feature = "unstable"))]
-mod hash_map {
-    use std::hash::Hash;
-
-    // Default state: Random SipHasher
-    pub type HashMap<K, V> = ::std::collections::HashMap<K, V>;
-
-    pub fn new<K, V>() -> HashMap<K, V> where K: Hash + Eq {
-        ::std::collections::HashMap::new()
-    }
-}
+pub type HashMap<K, V> = ::std::collections::HashMap<K, V, ::std::hash::BuildHasherDefault<::fnv::FnvHasher>>;

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -13,7 +13,7 @@ use string_cache::Atom;
 use parser::{CaseSensitivity, Combinator, CompoundSelector, LocalName};
 use parser::{SimpleSelector, Selector, SelectorImpl};
 use tree::Element;
-use hash_map::{self, HashMap};
+use HashMap;
 
 /// The definition of whitespace per CSS Selectors Level 3 § 4.
 pub static SELECTOR_WHITESPACE: &'static [char] = &[' ', '\t', '\n', '\r', '\x0C'];
@@ -55,10 +55,10 @@ pub struct SelectorMap<T, Impl: SelectorImpl> {
 impl<T, Impl: SelectorImpl> SelectorMap<T, Impl> {
     pub fn new() -> SelectorMap<T, Impl> {
         SelectorMap {
-            id_hash: hash_map::new(),
-            class_hash: hash_map::new(),
-            local_name_hash: hash_map::new(),
-            lower_local_name_hash: hash_map::new(),
+            id_hash: HashMap::default(),
+            class_hash: HashMap::default(),
+            local_name_hash: HashMap::default(),
+            lower_local_name_hash: HashMap::default(),
             universal_rules: vec!(),
             empty: true,
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,7 +14,7 @@ use heapsize::HeapSizeOf;
 use cssparser::{Token, Parser, parse_nth};
 use string_cache::{Atom, Namespace};
 
-use hash_map;
+use HashMap;
 
 /// This trait allows to define the parser implementation in regards
 /// of pseudo-classes/elements
@@ -50,7 +50,7 @@ pub trait SelectorImpl {
 pub struct ParserContext {
     pub in_user_agent_stylesheet: bool,
     pub default_namespace: Option<Namespace>,
-    pub namespace_prefixes: hash_map::HashMap<String, Namespace>,
+    pub namespace_prefixes: HashMap<String, Namespace>,
 }
 
 impl ParserContext {
@@ -58,7 +58,7 @@ impl ParserContext {
         ParserContext {
             in_user_agent_stylesheet: false,
             default_namespace: None,
-            namespace_prefixes: hash_map::new(),
+            namespace_prefixes: HashMap::default(),
         }
     }
 }


### PR DESCRIPTION
Custom hashers are now stable.

This raises the minimum Rust version to 1.7 (the current stable).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-selectors/76)

<!-- Reviewable:end -->
