### PR TITLE
Treat missing type selector as universal selector in the default namespace

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -460,7 +460,8 @@ fn parse_attribute_flags(input: &mut Parser) -> Result<CaseSensitivity, ()> {
 }
 
 
-/// Level 3: Parse **one** simple_selector
+/// Level 3: Parse **one** simple_selector.  (Though we might insert a second
+/// implied "<defaultns>|*" type selector.)
 fn parse_negation<Impl: SelectorImpl>(context: &ParserContext,
                                       input: &mut Parser)
                                       -> Result<SimpleSelector<Impl>, ()> {
@@ -471,7 +472,14 @@ fn parse_negation<Impl: SelectorImpl>(context: &ParserContext,
                                                  input,
                                                  /* inside_negation = */ true)) {
                 Some(SimpleSelectorParseResult::SimpleSelector(simple_selector)) => {
-                    Ok(SimpleSelector::Negation(vec![simple_selector]))
+                    let simple_selectors = match context.default_namespace {
+                        // If there was no explicit type selector, but there is
+                        // a default namespace, there is an implicit
+                        // "<defaultns>|*" type selector before simple_selector.
+                        Some(ref ns) => vec![SimpleSelector::Namespace(ns.clone()), simple_selector],
+                        None => vec![simple_selector],
+                    };
+                    Ok(SimpleSelector::Negation(simple_selectors))
                 }
                 _ => Err(())
             }
@@ -497,7 +505,15 @@ fn parse_simple_selectors<Impl: SelectorImpl>(context: &ParserContext,
     }
     let mut empty = true;
     let mut simple_selectors = match try!(parse_type_selector(context, input)) {
-        None => vec![],
+        None => {
+            match context.default_namespace {
+                // If there was no explicit type selector, but there is a
+                // default namespace, there is an implicit "<defaultns>|*" type
+                // selector.
+                Some(ref ns) => vec![SimpleSelector::Namespace(ns.clone())],
+                None => vec![],
+            }
+        }
         Some(s) => { empty = false; s }
     };
 


### PR DESCRIPTION
When a simple selector sequence has no type selector in it, there should be an implicit universal selector in the default namespace.  For example `.a` should be equivalent to `*.a` (and not to `*|*.a`).  Currently, we don't generate a SimpleSelector::Namespace for the default namespace if we don't parse an explicit type selector, which means the following test fails:

``` html
<!DOCTYPE html>
<style>
@namespace url("http://example.com/");
*|*.a { color: green; }
.a { color: red; }
*|*.b { color: red; }
*|*.b:not(p) { color: green; }
</style>
<p class=a>This text should be green.</p>
<p class=b>This text should be green.</p>
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-selectors/82)

<!-- Reviewable:end -->
