### PR TITLE
Switch from &Atom and &Namespace to BorrowedAtom and BorrowedNamespace.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rust:
     - stable
 script:
     - cargo test
-    - ([ $TRAVIS_RUST_VERSION == stable ] || cargo build --features gecko_atom)
     - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --features unstable)
 
 branches:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ string_cache = "0.2.16"
 quickersort = "2.0.0"
 heapsize = {version = ">=0.1.1, <0.4", features = ["unstable"], optional = true}
 heapsize_plugin = {version = "0.1.0", optional = true}
-gecko_atom = {version = "1.0.0", optional = true}
 
 [dev-dependencies]
 rand = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "selectors"
-version = "0.5.9"
+version = "0.5.10"
 authors = ["Simon Sapin <simon.sapin@exyr.org>", "Alan Jeffrey <ajeffrey@mozilla.com>"]
 documentation = "http://doc.servo.org/selectors/"
 
@@ -21,7 +21,7 @@ matches = "0.1"
 cssparser = "0.5"
 smallvec = "0.1"
 fnv = "1.0"
-string_cache = "0.2.13"
+string_cache = "0.2.16"
 quickersort = "2.0.0"
 heapsize = {version = ">=0.1.1, <0.4", features = ["unstable"], optional = true}
 heapsize_plugin = {version = "0.1.0", optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,7 @@
 #[macro_use] extern crate cssparser;
 #[macro_use] extern crate matches;
 #[cfg(test)] extern crate rand;
-#[cfg(not(feature = "gecko_atom"))] #[macro_use] extern crate string_cache;
-#[cfg(feature = "gecko_atom")] #[macro_use] extern crate gecko_atom as string_cache;
+#[macro_use] extern crate string_cache;
 extern crate quickersort;
 extern crate smallvec;
 extern crate fnv;

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -112,7 +112,7 @@ impl<T, Impl: SelectorImpl> SelectorMap<T, Impl> {
         SelectorMap::get_matching_rules_from_hash(element,
                                                   parent_bf,
                                                   local_name_hash,
-                                                  element.get_local_name(),
+                                                  &element.get_local_name(),
                                                   matching_rules_list,
                                                   shareable);
 
@@ -604,10 +604,10 @@ pub fn matches_simple_selector<E>(selector: &SimpleSelector<E::Impl>,
     match *selector {
         SimpleSelector::LocalName(LocalName { ref name, ref lower_name }) => {
             let name = if element.is_html_element_in_html_document() { lower_name } else { name };
-            element.get_local_name() == name
+            element.get_local_name() == *name
         }
         SimpleSelector::Namespace(ref namespace) => {
-            element.get_namespace() == namespace
+            element.get_namespace() == *namespace
         }
         // TODO: case-sensitivity depends on the document type and quirks mode
         SimpleSelector::ID(ref id) => {
@@ -767,8 +767,8 @@ fn matches_generic_nth_child<E>(element: &E,
         };
 
         if is_of_type {
-            if element.get_local_name() == sibling.get_local_name() &&
-                element.get_namespace() == sibling.get_namespace() {
+            if element.get_local_name() == *sibling.get_local_name() &&
+                element.get_namespace() == *sibling.get_namespace() {
                 index += 1;
             }
         } else {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -7,7 +7,7 @@
 
 use matching::ElementFlags;
 use parser::{AttrSelector, SelectorImpl};
-use string_cache::{Atom, Namespace};
+use string_cache::{Atom, BorrowedAtom, BorrowedNamespace};
 
 pub trait Element: Sized {
     type Impl: SelectorImpl;
@@ -27,8 +27,8 @@ pub trait Element: Sized {
     fn next_sibling_element(&self) -> Option<Self>;
 
     fn is_html_element_in_html_document(&self) -> bool;
-    fn get_local_name<'a>(&'a self) -> &'a Atom;
-    fn get_namespace<'a>(&'a self) -> &'a Namespace;
+    fn get_local_name<'a>(&'a self) -> BorrowedAtom<'a>;
+    fn get_namespace<'a>(&'a self) -> BorrowedNamespace<'a>;
 
     fn match_non_ts_pseudo_class(&self, pc: <Self::Impl as SelectorImpl>::NonTSPseudoClass) -> bool;
 


### PR DESCRIPTION
In the regular string_cache, these structs just behave like normal borrows. In
geckolib, these pass around nsIAtom pointers without addref-ing them.

This depends on https://github.com/servo/string-cache/pull/155

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-selectors/88)

<!-- Reviewable:end -->
