### PR TITLE
Refactor attribute handling to remove the requirement to get attributes as strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "selectors"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>", "Alan Jeffrey <ajeffrey@mozilla.com>"]
 documentation = "http://doc.servo.org/selectors/"
 
@@ -12,6 +12,7 @@ keywords = ["css", "selectors"]
 license = "MPL-2.0"
 
 [features]
+gecko = []
 unstable = ["string_cache/unstable"]
 heap_size = ["string_cache/heap_size", "heapsize", "heapsize_plugin"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,5 +21,6 @@ pub mod parser;
 mod tree;
 
 pub use tree::Element;
+pub use tree::{MatchAttr, MatchAttrGeneric};
 
 pub type HashMap<K, V> = ::std::collections::HashMap<K, V, ::std::hash::BuildHasherDefault<::fnv::FnvHasher>>;

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-use std::ascii::AsciiExt;
 use std::cmp::Ordering;
 use std::sync::Arc;
 
@@ -14,9 +13,6 @@ use parser::{CaseSensitivity, Combinator, CompoundSelector, LocalName};
 use parser::{SimpleSelector, Selector, SelectorImpl};
 use tree::Element;
 use HashMap;
-
-/// The definition of whitespace per CSS Selectors Level 3 § 4.
-pub static SELECTOR_WHITESPACE: &'static [char] = &[' ', '\t', '\n', '\r', '\x0C'];
 
 /// Map element data to Rules whose last simple selector starts with them.
 ///
@@ -630,7 +626,7 @@ pub fn matches_simple_selector<E>(selector: &SimpleSelector<E::Impl>,
             }) {
                 *shareable = false;
             }
-            element.match_attr(attr, |_| true)
+            element.match_attr_has(attr)
         }
         SimpleSelector::AttrEqual(ref attr, ref value, case_sensitivity) => {
             if *value != "dir" &&
@@ -644,43 +640,30 @@ pub fn matches_simple_selector<E>(selector: &SimpleSelector<E::Impl>,
                 // here because the UA style otherwise disables all style sharing completely.
                 *shareable = false
             }
-            element.match_attr(attr, |attr_value| {
-                match case_sensitivity {
-                    CaseSensitivity::CaseSensitive => attr_value == *value,
-                    CaseSensitivity::CaseInsensitive => attr_value.eq_ignore_ascii_case(value),
-                }
-            })
+            match case_sensitivity {
+                CaseSensitivity::CaseSensitive => element.match_attr_equals(attr, value),
+                CaseSensitivity::CaseInsensitive => element.match_attr_equals_ignore_ascii_case(attr, value),
+            }
         }
         SimpleSelector::AttrIncludes(ref attr, ref value) => {
             *shareable = false;
-            element.match_attr(attr, |attr_value| {
-                attr_value.split(SELECTOR_WHITESPACE).any(|v| v == *value)
-            })
+            element.match_attr_includes(attr, value)
         }
         SimpleSelector::AttrDashMatch(ref attr, ref value, ref dashing_value) => {
             *shareable = false;
-            element.match_attr(attr, |attr_value| {
-                attr_value == *value ||
-                attr_value.starts_with(dashing_value)
-            })
+            element.match_attr_dash(attr, value, dashing_value)
         }
         SimpleSelector::AttrPrefixMatch(ref attr, ref value) => {
             *shareable = false;
-            element.match_attr(attr, |attr_value| {
-                attr_value.starts_with(value)
-            })
+            element.match_attr_prefix(attr, value)
         }
         SimpleSelector::AttrSubstringMatch(ref attr, ref value) => {
             *shareable = false;
-            element.match_attr(attr, |attr_value| {
-                attr_value.contains(value)
-            })
+            element.match_attr_substring(attr, value)
         }
         SimpleSelector::AttrSuffixMatch(ref attr, ref value) => {
             *shareable = false;
-            element.match_attr(attr, |attr_value| {
-                attr_value.ends_with(value)
-            })
+            element.match_attr_suffix(attr, value)
         }
         SimpleSelector::NonTSPseudoClass(ref pc) => {
             *shareable = false;

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -633,7 +633,7 @@ pub fn matches_simple_selector<E>(selector: &SimpleSelector<E::Impl>,
             element.match_attr(attr, |_| true)
         }
         SimpleSelector::AttrEqual(ref attr, ref value, case_sensitivity) => {
-            if *value != "DIR" &&
+            if *value != "dir" &&
                     common_style_affecting_attributes().iter().all(|common_attr_info| {
                         !(common_attr_info.atom == attr.name && match common_attr_info.mode {
                             CommonStyleAffectingAttributeMode::IsEqual(target_value, _) => *value == target_value,

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -649,9 +649,9 @@ pub fn matches_simple_selector<E>(selector: &SimpleSelector<E::Impl>,
             *shareable = false;
             element.match_attr_includes(attr, value)
         }
-        SimpleSelector::AttrDashMatch(ref attr, ref value, ref dashing_value) => {
+        SimpleSelector::AttrDashMatch(ref attr, ref value) => {
             *shareable = false;
-            element.match_attr_dash(attr, value, dashing_value)
+            element.match_attr_dash(attr, value)
         }
         SimpleSelector::AttrPrefixMatch(ref attr, ref value) => {
             *shareable = false;

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -545,10 +545,10 @@ pub struct CommonStyleAffectingAttributeInfo {
     pub mode: CommonStyleAffectingAttributeMode,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub enum CommonStyleAffectingAttributeMode {
     IsPresent(CommonStyleAffectingAttributes),
-    IsEqual(&'static str, CommonStyleAffectingAttributes),
+    IsEqual(Atom, CommonStyleAffectingAttributes),
 }
 
 // NB: This must match the order in `selectors::matching::CommonStyleAffectingAttributes`.
@@ -565,15 +565,15 @@ pub fn common_style_affecting_attributes() -> [CommonStyleAffectingAttributeInfo
         },
         CommonStyleAffectingAttributeInfo {
             atom: atom!("align"),
-            mode: CommonStyleAffectingAttributeMode::IsEqual("left", ALIGN_LEFT_ATTRIBUTE),
+            mode: CommonStyleAffectingAttributeMode::IsEqual(atom!("left"), ALIGN_LEFT_ATTRIBUTE),
         },
         CommonStyleAffectingAttributeInfo {
             atom: atom!("align"),
-            mode: CommonStyleAffectingAttributeMode::IsEqual("center", ALIGN_CENTER_ATTRIBUTE),
+            mode: CommonStyleAffectingAttributeMode::IsEqual(atom!("center"), ALIGN_CENTER_ATTRIBUTE),
         },
         CommonStyleAffectingAttributeInfo {
             atom: atom!("align"),
-            mode: CommonStyleAffectingAttributeMode::IsEqual("right", ALIGN_RIGHT_ATTRIBUTE),
+            mode: CommonStyleAffectingAttributeMode::IsEqual(atom!("right"), ALIGN_RIGHT_ATTRIBUTE),
         }
     ]
 }
@@ -632,7 +632,7 @@ pub fn matches_simple_selector<E>(selector: &SimpleSelector<E::Impl>,
             if *value != "dir" &&
                     common_style_affecting_attributes().iter().all(|common_attr_info| {
                         !(common_attr_info.atom == attr.name && match common_attr_info.mode {
-                            CommonStyleAffectingAttributeMode::IsEqual(target_value, _) => *value == target_value,
+                            CommonStyleAffectingAttributeMode::IsEqual(ref target_value, _) => *value == &**target_value,
                             CommonStyleAffectingAttributeMode::IsPresent(_) => false,
                         })
                     }) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -16,9 +16,52 @@ use string_cache::{Atom, Namespace};
 
 use HashMap;
 
+// The MaybeAtom trait allows consumers to decide whether to store attribute
+// selector strings as atoms or raw strings. Gecko uses atoms to get around
+// UTF-16 issues, whereas Servo uses strings to avoid mostly-unnecessary
+// atomization costs.
+#[cfg(feature = "heap_size")]
+pub trait MaybeAtom: Clone + Debug + HeapSizeOf + PartialEq {
+    fn equals_atom(&self, other: &Atom) -> bool;
+    fn from_cow_str(cow: Cow<str>) -> Self;
+}
+
+#[cfg(not(feature = "heap_size"))]
+pub trait MaybeAtom: Clone + Debug + PartialEq {
+    fn equals_atom(&self, other: &Atom) -> bool;
+    fn from_cow_str(cow: Cow<str>) -> Self;
+}
+
+impl MaybeAtom for String {
+    #[cfg(not(feature = "gecko"))]
+    fn equals_atom(&self, other: &Atom) -> bool {
+        self == &**other
+    }
+    #[cfg(feature = "gecko")]
+    fn equals_atom(&self, _: &Atom) -> bool {
+        // We could implement this with a smart UTF-8/UTF-16 comparator over
+        // FFI, but we don't need it since we use Atoms for Gecko.
+        unimplemented!()
+    }
+    fn from_cow_str(cow: Cow<str>) -> Self {
+        cow.into_owned()
+    }
+}
+
+impl MaybeAtom for Atom {
+    fn equals_atom(&self, other: &Atom) -> bool {
+        self == other
+    }
+    fn from_cow_str(cow: Cow<str>) -> Self {
+        Atom::from(cow)
+    }
+}
+
 /// This trait allows to define the parser implementation in regards
 /// of pseudo-classes/elements
 pub trait SelectorImpl {
+    type AttrString: MaybeAtom;
+
     /// non tree-structural pseudo-classes
     /// (see: https://drafts.csswg.org/selectors/#structural-pseudos)
     #[cfg(feature = "heap_size")]
@@ -97,12 +140,12 @@ pub enum SimpleSelector<Impl: SelectorImpl> {
 
     // Attribute selectors
     AttrExists(AttrSelector),  // [foo]
-    AttrEqual(AttrSelector, String, CaseSensitivity),  // [foo=bar]
-    AttrIncludes(AttrSelector, String),  // [foo~=bar]
-    AttrDashMatch(AttrSelector, String), // [foo|=bar]
-    AttrPrefixMatch(AttrSelector, String),  // [foo^=bar]
-    AttrSubstringMatch(AttrSelector, String),  // [foo*=bar]
-    AttrSuffixMatch(AttrSelector, String),  // [foo$=bar]
+    AttrEqual(AttrSelector, Impl::AttrString, CaseSensitivity),  // [foo=bar]
+    AttrIncludes(AttrSelector, Impl::AttrString),  // [foo~=bar]
+    AttrDashMatch(AttrSelector, Impl::AttrString), // [foo|=bar]
+    AttrPrefixMatch(AttrSelector, Impl::AttrString),  // [foo^=bar]
+    AttrSubstringMatch(AttrSelector, Impl::AttrString),  // [foo*=bar]
+    AttrSuffixMatch(AttrSelector, Impl::AttrString),  // [foo$=bar]
 
     // Pseudo-classes
     Negation(Vec<SimpleSelector<Impl>>),
@@ -409,8 +452,8 @@ fn parse_attribute_selector<Impl: SelectorImpl>(context: &ParserContext, input: 
         },
     };
 
-    fn parse_value(input: &mut Parser) -> Result<String, ()> {
-        Ok((try!(input.expect_ident_or_string())).into_owned())
+    fn parse_value<Impl: SelectorImpl>(input: &mut Parser) -> Result<Impl::AttrString, ()> {
+        Ok(Impl::AttrString::from_cow_str(try!(input.expect_ident_or_string())))
     }
     // TODO: deal with empty value or value containing whitespace (see spec)
     match input.next() {
@@ -419,29 +462,29 @@ fn parse_attribute_selector<Impl: SelectorImpl>(context: &ParserContext, input: 
 
         // [foo=bar]
         Ok(Token::Delim('=')) => {
-            Ok(SimpleSelector::AttrEqual(attr, try!(parse_value(input)),
+            Ok(SimpleSelector::AttrEqual(attr, try!(parse_value::<Impl>(input)),
                                          try!(parse_attribute_flags(input))))
         }
         // [foo~=bar]
         Ok(Token::IncludeMatch) => {
-            Ok(SimpleSelector::AttrIncludes(attr, try!(parse_value(input))))
+            Ok(SimpleSelector::AttrIncludes(attr, try!(parse_value::<Impl>(input))))
         }
         // [foo|=bar]
         Ok(Token::DashMatch) => {
-            let value = try!(parse_value(input));
+            let value = try!(parse_value::<Impl>(input));
             Ok(SimpleSelector::AttrDashMatch(attr, value))
         }
         // [foo^=bar]
         Ok(Token::PrefixMatch) => {
-            Ok(SimpleSelector::AttrPrefixMatch(attr, try!(parse_value(input))))
+            Ok(SimpleSelector::AttrPrefixMatch(attr, try!(parse_value::<Impl>(input))))
         }
         // [foo*=bar]
         Ok(Token::SubstringMatch) => {
-            Ok(SimpleSelector::AttrSubstringMatch(attr, try!(parse_value(input))))
+            Ok(SimpleSelector::AttrSubstringMatch(attr, try!(parse_value::<Impl>(input))))
         }
         // [foo$=bar]
         Ok(Token::SuffixMatch) => {
-            Ok(SimpleSelector::AttrSuffixMatch(attr, try!(parse_value(input))))
+            Ok(SimpleSelector::AttrSuffixMatch(attr, try!(parse_value::<Impl>(input))))
         }
         _ => Err(())
     }
@@ -680,6 +723,7 @@ pub mod tests {
     pub struct DummySelectorImpl;
 
     impl SelectorImpl for DummySelectorImpl {
+        type AttrString = String;
         type NonTSPseudoClass = PseudoClass;
         fn parse_non_ts_pseudo_class(context: &ParserContext, name: &str) -> Result<PseudoClass, ()> {
             match_ignore_ascii_case! { name,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -99,7 +99,7 @@ pub enum SimpleSelector<Impl: SelectorImpl> {
     AttrExists(AttrSelector),  // [foo]
     AttrEqual(AttrSelector, String, CaseSensitivity),  // [foo=bar]
     AttrIncludes(AttrSelector, String),  // [foo~=bar]
-    AttrDashMatch(AttrSelector, String, String), // [foo|=bar]  Second string is the first + "-"
+    AttrDashMatch(AttrSelector, String), // [foo|=bar]
     AttrPrefixMatch(AttrSelector, String),  // [foo^=bar]
     AttrSubstringMatch(AttrSelector, String),  // [foo*=bar]
     AttrSuffixMatch(AttrSelector, String),  // [foo$=bar]
@@ -429,8 +429,7 @@ fn parse_attribute_selector<Impl: SelectorImpl>(context: &ParserContext, input: 
         // [foo|=bar]
         Ok(Token::DashMatch) => {
             let value = try!(parse_value(input));
-            let dashing_value = format!("{}-", value);
-            Ok(SimpleSelector::AttrDashMatch(attr, value, dashing_value))
+            Ok(SimpleSelector::AttrDashMatch(attr, value))
         }
         // [foo^=bar]
         Ok(Token::PrefixMatch) => {
@@ -847,7 +846,7 @@ pub mod tests {
                         name: Atom::from("attr"),
                         lower_name: Atom::from("attr"),
                         namespace: NamespaceConstraint::Specific(ns!()),
-                    }, "foo".to_owned(), "foo-".to_owned())
+                    }, "foo".to_owned())
                 ],
                 next: None,
             }),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -6,7 +6,7 @@
 //! style.
 
 use matching::ElementFlags;
-use parser::{AttrSelector, SelectorImpl};
+use parser::{AttrSelector, MaybeAtom, SelectorImpl};
 use std::ascii::AsciiExt;
 use string_cache::{Atom, BorrowedAtom, BorrowedNamespace};
 
@@ -16,14 +16,15 @@ pub static SELECTOR_WHITESPACE: &'static [char] = &[' ', '\t', '\n', '\r', '\x0C
 // Attribute matching routines. Consumers with simple implementations can implement
 // MatchAttrGeneric instead.
 pub trait MatchAttr {
+    type AttrString: MaybeAtom;
     fn match_attr_has(&self, attr: &AttrSelector) -> bool;
-    fn match_attr_equals(&self, attr: &AttrSelector, value: &str) -> bool;
-    fn match_attr_equals_ignore_ascii_case(&self, attr: &AttrSelector, value: &str) -> bool;
-    fn match_attr_includes(&self, attr: &AttrSelector, value: &str) -> bool;
-    fn match_attr_dash(&self, attr: &AttrSelector, value: &str) -> bool;
-    fn match_attr_prefix(&self, attr: &AttrSelector, value: &str) -> bool;
-    fn match_attr_substring(&self, attr: &AttrSelector, value: &str) -> bool;
-    fn match_attr_suffix(&self, attr: &AttrSelector, value: &str) -> bool;
+    fn match_attr_equals(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
+    fn match_attr_equals_ignore_ascii_case(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
+    fn match_attr_includes(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
+    fn match_attr_dash(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
+    fn match_attr_prefix(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
+    fn match_attr_substring(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
+    fn match_attr_suffix(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
 }
 
 pub trait MatchAttrGeneric {
@@ -31,21 +32,22 @@ pub trait MatchAttrGeneric {
 }
 
 impl<T> MatchAttr for T where T: MatchAttrGeneric {
+    type AttrString = String;
     fn match_attr_has(&self, attr: &AttrSelector) -> bool {
         self.match_attr(attr, |_| true)
     }
-    fn match_attr_equals(&self, attr: &AttrSelector, value: &str) -> bool {
+    fn match_attr_equals(&self, attr: &AttrSelector, value: &String) -> bool {
         self.match_attr(attr, |v| v == value)
     }
-    fn match_attr_equals_ignore_ascii_case(&self, attr: &AttrSelector, value: &str) -> bool {
+    fn match_attr_equals_ignore_ascii_case(&self, attr: &AttrSelector, value: &String) -> bool {
         self.match_attr(attr, |v| v.eq_ignore_ascii_case(value))
     }
-    fn match_attr_includes(&self, attr: &AttrSelector, value: &str) -> bool {
+    fn match_attr_includes(&self, attr: &AttrSelector, value: &String) -> bool {
         self.match_attr(attr, |attr_value| {
             attr_value.split(SELECTOR_WHITESPACE).any(|v| v == value)
         })
     }
-    fn match_attr_dash(&self, attr: &AttrSelector, value: &str) -> bool {
+    fn match_attr_dash(&self, attr: &AttrSelector, value: &String) -> bool {
         self.match_attr(attr, |attr_value| {
 
             // The attribute must start with the pattern.
@@ -62,17 +64,17 @@ impl<T> MatchAttr for T where T: MatchAttrGeneric {
             attr_value.as_bytes()[value.len()] == '-' as u8
         })
     }
-    fn match_attr_prefix(&self, attr: &AttrSelector, value: &str) -> bool {
+    fn match_attr_prefix(&self, attr: &AttrSelector, value: &String) -> bool {
         self.match_attr(attr, |attr_value| {
             attr_value.starts_with(value)
         })
     }
-    fn match_attr_substring(&self, attr: &AttrSelector, value: &str) -> bool {
+    fn match_attr_substring(&self, attr: &AttrSelector, value: &String) -> bool {
         self.match_attr(attr, |attr_value| {
             attr_value.contains(value)
         })
     }
-    fn match_attr_suffix(&self, attr: &AttrSelector, value: &str) -> bool {
+    fn match_attr_suffix(&self, attr: &AttrSelector, value: &String) -> bool {
         self.match_attr(attr, |attr_value| {
             attr_value.ends_with(value)
         })
@@ -80,7 +82,7 @@ impl<T> MatchAttr for T where T: MatchAttrGeneric {
 }
 
 pub trait Element: MatchAttr + Sized {
-    type Impl: SelectorImpl;
+    type Impl: SelectorImpl<AttrString = <Self as MatchAttr>::AttrString>;
 
     fn parent_element(&self) -> Option<Self>;
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -20,7 +20,7 @@ pub trait MatchAttr {
     fn match_attr_equals(&self, attr: &AttrSelector, value: &str) -> bool;
     fn match_attr_equals_ignore_ascii_case(&self, attr: &AttrSelector, value: &str) -> bool;
     fn match_attr_includes(&self, attr: &AttrSelector, value: &str) -> bool;
-    fn match_attr_dash(&self, attr: &AttrSelector, value: &str, dashing_value: &str) -> bool;
+    fn match_attr_dash(&self, attr: &AttrSelector, value: &str) -> bool;
     fn match_attr_prefix(&self, attr: &AttrSelector, value: &str) -> bool;
     fn match_attr_substring(&self, attr: &AttrSelector, value: &str) -> bool;
     fn match_attr_suffix(&self, attr: &AttrSelector, value: &str) -> bool;
@@ -45,10 +45,21 @@ impl<T> MatchAttr for T where T: MatchAttrGeneric {
             attr_value.split(SELECTOR_WHITESPACE).any(|v| v == value)
         })
     }
-    fn match_attr_dash(&self, attr: &AttrSelector, value: &str, dashing_value: &str) -> bool {
+    fn match_attr_dash(&self, attr: &AttrSelector, value: &str) -> bool {
         self.match_attr(attr, |attr_value| {
-            attr_value == value ||
-            attr_value.starts_with(dashing_value)
+
+            // The attribute must start with the pattern.
+            if !attr_value.starts_with(value) {
+                return false
+            }
+
+            // If the strings are the same, we're done.
+            if attr_value.len() == value.len() {
+                return true
+            }
+
+            // The attribute is long than the pattern, so the next character must be '-'.
+            attr_value.as_bytes()[value.len()] == '-' as u8
         })
     }
     fn match_attr_prefix(&self, attr: &AttrSelector, value: &str) -> bool {


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-selectors/91)

<!-- Reviewable:end -->
