### PR TITLE
Make selectors generic over atom types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "selectors"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>", "Alan Jeffrey <ajeffrey@mozilla.com>"]
 documentation = "http://doc.servo.org/selectors/"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["css", "selectors"]
 license = "MPL-2.0"
 
 [features]
-gecko = []
 unstable = ["string_cache/unstable"]
 heap_size = ["string_cache/heap_size", "heapsize", "heapsize_plugin"]
 

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -199,6 +199,13 @@ impl BloomHash for Namespace {
     }
 }
 
+impl BloomHash for String {
+    #[inline]
+    fn bloom_hash(&self) -> u32 {
+        unimplemented!()
+    }
+}
+
 #[inline]
 fn full(slot: &u8) -> bool {
     *slot == 0xff

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -4,6 +4,8 @@
 
 //! Simple counting bloom filters.
 
+use fnv::FnvHasher;
+use std::hash::Hasher;
 use string_cache::{Atom, Namespace};
 
 const KEY_SIZE: usize = 12;
@@ -168,6 +170,13 @@ pub trait BloomHash {
     fn bloom_hash(&self) -> u32;
 }
 
+impl BloomHash for u64 {
+    #[inline]
+    fn bloom_hash(&self) -> u32 {
+        ((*self >> 32) ^ *self) as u32
+    }
+}
+
 impl BloomHash for isize {
     #[allow(exceeding_bitshifts)]
     #[inline]
@@ -202,7 +211,9 @@ impl BloomHash for Namespace {
 impl BloomHash for String {
     #[inline]
     fn bloom_hash(&self) -> u32 {
-        unimplemented!()
+        let mut h = FnvHasher::default();
+        h.write(self.as_bytes());
+        h.finish().bloom_hash()
     }
 }
 

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::sync::Arc;
 
@@ -548,7 +549,7 @@ pub fn matches_simple_selector<'a, E>(selector: &SimpleSelector<E::Impl>,
             element.get_local_name() == *name
         }
         SimpleSelector::Namespace(ref namespace) => {
-            element.get_namespace() == E::Impl::borrow_namespace(namespace)
+            element.get_namespace() == namespace.borrow()
         }
         // TODO: case-sensitivity depends on the document type and quirks mode
         SimpleSelector::ID(ref id) => {

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -144,17 +144,17 @@ impl<T, Impl: SelectorImpl> SelectorMap<T, Impl> {
         sort_by(&mut matching_rules_list[init_len..], &compare);
     }
 
-    fn get_matching_rules_from_hash<E, S, B: ?Sized, V>(
+    fn get_matching_rules_from_hash<E, Str, BorrowedStr: ?Sized, Vector>(
         element: &E,
         parent_bf: Option<&BloomFilter>,
-        hash: &HashMap<S, Vec<Rule<T, Impl>>>,
-        key: &B,
-        matching_rules: &mut V,
+        hash: &HashMap<Str, Vec<Rule<T, Impl>>>,
+        key: &BorrowedStr,
+        matching_rules: &mut Vector,
         shareable: &mut bool)
     where E: Element<Impl=Impl>,
-          S: Borrow<B> + Eq + Hash,
-          B: Eq + Hash,
-          V: VecLike<DeclarationBlock<T>>
+          Str: Borrow<BorrowedStr> + Eq + Hash,
+          BorrowedStr: Eq + Hash,
+          Vector: VecLike<DeclarationBlock<T>>
     {
         match hash.get(key) {
             Some(rules) => {
@@ -549,7 +549,7 @@ pub fn matches_simple_selector<'a, E>(selector: &SimpleSelector<E::Impl>,
                                       element: &'a E,
                                       shareable: &mut bool)
                                       -> bool
-                                     where E: Element {
+                                      where E: Element {
     match *selector {
         SimpleSelector::LocalName(LocalName { ref name, ref lower_name }) => {
             let name = if element.is_html_element_in_html_document() { lower_name } else { name };
@@ -748,9 +748,9 @@ fn matches_last_child<E>(element: &E) -> bool where E: Element {
     result
 }
 
-fn find_push<T, Impl: SelectorImpl, S: Eq + Hash>(
-    map: &mut HashMap<S, Vec<Rule<T, Impl>>>,
-    key: S,
+fn find_push<T, Impl: SelectorImpl, Str: Eq + Hash>(
+    map: &mut HashMap<Str, Vec<Rule<T, Impl>>>,
+    key: Str,
     value: Rule<T, Impl>
 ) {
     if let Some(vec) = map.get_mut(&key) {

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -578,13 +578,6 @@ pub fn common_style_affecting_attributes() -> [CommonStyleAffectingAttributeInfo
     ]
 }
 
-/// Attributes that, if present, disable style sharing. All legacy HTML attributes must be in
-/// either this list or `common_style_affecting_attributes`. See the comment in
-/// `synthesize_presentational_hints_for_legacy_attributes`.
-pub fn rare_style_affecting_attributes() -> [Atom; 3] {
-    [ atom!("bgcolor"), atom!("border"), atom!("colspan") ]
-}
-
 /// Determines whether the given element matches the given single selector.
 ///
 /// NB: If you add support for any new kinds of selectors to this routine, be sure to set

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use bloom::BloomFilter;
 use smallvec::VecLike;
 use quickersort::sort_by;
-use string_cache::Atom;
+use string_cache::{self, Atom};
 
 use parser::{CaseSensitivity, Combinator, CompoundSelector, LocalName};
 use parser::{SimpleSelector, Selector, SelectorImpl};
@@ -548,7 +548,8 @@ pub fn matches_simple_selector<E>(selector: &SimpleSelector<E::Impl>,
             element.get_local_name() == *name
         }
         SimpleSelector::Namespace(ref namespace) => {
-            element.get_namespace() == *namespace
+            // UFCS to work around https://github.com/rust-lang/rust/issues/34792
+            PartialEq::<string_cache::Namespace>::eq(&element.get_namespace(), namespace)
         }
         // TODO: case-sensitivity depends on the document type and quirks mode
         SimpleSelector::ID(ref id) => {
@@ -681,7 +682,7 @@ fn matches_generic_nth_child<E>(element: &E,
 
         if is_of_type {
             if element.get_local_name() == *sibling.get_local_name() &&
-                element.get_namespace() == *sibling.get_namespace() {
+                element.get_namespace() == sibling.get_namespace() {
                 index += 1;
             }
         } else {

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -74,7 +74,7 @@ impl<T, Impl: SelectorImpl> SelectorMap<T, Impl> {
                                         parent_bf: Option<&BloomFilter>,
                                         matching_rules_list: &mut V,
                                         shareable: &mut bool)
-                                        where E: Element<Impl=Impl, AttrString=Impl::AttrString>,
+                                        where E: Element<Impl=Impl, AttrValue=Impl::AttrValue>,
                                               V: VecLike<DeclarationBlock<T>> {
         if self.empty {
             return
@@ -149,7 +149,7 @@ impl<T, Impl: SelectorImpl> SelectorMap<T, Impl> {
                                           key: &Atom,
                                           matching_rules: &mut V,
                                           shareable: &mut bool)
-                                          where E: Element<Impl=Impl, AttrString=Impl::AttrString>,
+                                          where E: Element<Impl=Impl, AttrValue=Impl::AttrValue>,
                                                 V: VecLike<DeclarationBlock<T>> {
         match hash.get(key) {
             Some(rules) => {
@@ -169,7 +169,7 @@ impl<T, Impl: SelectorImpl> SelectorMap<T, Impl> {
                                 rules: &[Rule<T, Impl>],
                                 matching_rules: &mut V,
                                 shareable: &mut bool)
-                                where E: Element<Impl=Impl, AttrString=Impl::AttrString>,
+                                where E: Element<Impl=Impl, AttrValue=Impl::AttrValue>,
                                       V: VecLike<DeclarationBlock<T>> {
         for rule in rules.iter() {
             if matches_compound_selector(&*rule.selector, element, parent_bf, shareable) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,30 +27,16 @@ use HashMap;
 // UTF-16 issues, whereas Servo uses strings to avoid mostly-unnecessary
 // atomization costs.
 pub trait MaybeAtom: Clone + Debug + MaybeHeapSizeOf + PartialEq {
-    fn equals_atom(&self, other: &Atom) -> bool;
     fn from_cow_str(cow: Cow<str>) -> Self;
 }
 
 impl MaybeAtom for String {
-    #[cfg(not(feature = "gecko"))]
-    fn equals_atom(&self, other: &Atom) -> bool {
-        self == &**other
-    }
-    #[cfg(feature = "gecko")]
-    fn equals_atom(&self, _: &Atom) -> bool {
-        // We could implement this with a smart UTF-8/UTF-16 comparator over
-        // FFI, but we don't need it since we use Atoms for Gecko.
-        unimplemented!()
-    }
     fn from_cow_str(cow: Cow<str>) -> Self {
         cow.into_owned()
     }
 }
 
 impl MaybeAtom for Atom {
-    fn equals_atom(&self, other: &Atom) -> bool {
-        self == other
-    }
     fn from_cow_str(cow: Cow<str>) -> Self {
         Atom::from(cow)
     }
@@ -60,6 +46,15 @@ impl MaybeAtom for Atom {
 /// of pseudo-classes/elements
 pub trait SelectorImpl {
     type AttrString: MaybeAtom;
+
+    fn attr_exists_selector_is_shareable(_attr_selector: &AttrSelector) -> bool {
+        false
+    }
+
+    fn attr_equals_selector_is_shareable(_attr_selector: &AttrSelector,
+                                         _value: &Self::AttrString) -> bool {
+        false
+    }
 
     /// non tree-structural pseudo-classes
     /// (see: https://drafts.csswg.org/selectors/#structural-pseudos)

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -6,10 +6,10 @@
 //! style.
 
 use matching::ElementFlags;
-use parser::{AttrSelector, MaybeHeapSizeOf, SelectorImpl};
+use parser::{AttrSelector, MaybeHeapSizeOf, SelectorImpl, TypeConstructor};
 use std::ascii::AsciiExt;
 use std::fmt::Debug;
-use string_cache::{Atom, BorrowedAtom, BorrowedNamespace};
+use string_cache::{Atom, BorrowedAtom};
 
 /// The definition of whitespace per CSS Selectors Level 3 § 4.
 pub static SELECTOR_WHITESPACE: &'static [char] = &[' ', '\t', '\n', '\r', '\x0C'];
@@ -101,7 +101,7 @@ pub trait Element: MatchAttr + Sized {
 
     fn is_html_element_in_html_document(&self) -> bool;
     fn get_local_name<'a>(&'a self) -> BorrowedAtom<'a>;
-    fn get_namespace<'a>(&'a self) -> BorrowedNamespace<'a>;
+    fn get_namespace<'a>(&'a self) -> <Self::Impl as TypeConstructor<'a>>::BorrowedNamespace;
 
     fn match_non_ts_pseudo_class(&self, pc: <Self::Impl as SelectorImpl>::NonTSPseudoClass) -> bool;
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -137,8 +137,8 @@ pub trait Element: MatchAttr + Sized {
     fn next_sibling_element(&self) -> Option<Self>;
 
     fn is_html_element_in_html_document(&self) -> bool;
-    fn get_local_name<'a>(&'a self) -> &<Self::Impl as SelectorImpl>::BorrowedLocalName;
-    fn get_namespace<'a>(&'a self) -> &<Self::Impl as SelectorImpl>::BorrowedNamespace;
+    fn get_local_name(&self) -> &<Self::Impl as SelectorImpl>::BorrowedLocalName;
+    fn get_namespace(&self) -> &<Self::Impl as SelectorImpl>::BorrowedNamespace;
 
     fn match_non_ts_pseudo_class(&self, pc: <Self::Impl as SelectorImpl>::NonTSPseudoClass) -> bool;
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -17,15 +17,15 @@ pub static SELECTOR_WHITESPACE: &'static [char] = &[' ', '\t', '\n', '\r', '\x0C
 // Attribute matching routines. Consumers with simple implementations can implement
 // MatchAttrGeneric instead.
 pub trait MatchAttr {
-    type AttrString: Clone + Debug + MaybeHeapSizeOf + PartialEq;
+    type AttrValue: Clone + Debug + MaybeHeapSizeOf + PartialEq;
     fn match_attr_has(&self, attr: &AttrSelector) -> bool;
-    fn match_attr_equals(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
-    fn match_attr_equals_ignore_ascii_case(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
-    fn match_attr_includes(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
-    fn match_attr_dash(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
-    fn match_attr_prefix(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
-    fn match_attr_substring(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
-    fn match_attr_suffix(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
+    fn match_attr_equals(&self, attr: &AttrSelector, value: &Self::AttrValue) -> bool;
+    fn match_attr_equals_ignore_ascii_case(&self, attr: &AttrSelector, value: &Self::AttrValue) -> bool;
+    fn match_attr_includes(&self, attr: &AttrSelector, value: &Self::AttrValue) -> bool;
+    fn match_attr_dash(&self, attr: &AttrSelector, value: &Self::AttrValue) -> bool;
+    fn match_attr_prefix(&self, attr: &AttrSelector, value: &Self::AttrValue) -> bool;
+    fn match_attr_substring(&self, attr: &AttrSelector, value: &Self::AttrValue) -> bool;
+    fn match_attr_suffix(&self, attr: &AttrSelector, value: &Self::AttrValue) -> bool;
 }
 
 pub trait MatchAttrGeneric {
@@ -33,7 +33,7 @@ pub trait MatchAttrGeneric {
 }
 
 impl<T> MatchAttr for T where T: MatchAttrGeneric {
-    type AttrString = String;
+    type AttrValue = String;
     fn match_attr_has(&self, attr: &AttrSelector) -> bool {
         self.match_attr(attr, |_| true)
     }
@@ -83,7 +83,7 @@ impl<T> MatchAttr for T where T: MatchAttrGeneric {
 }
 
 pub trait Element: MatchAttr + Sized {
-    type Impl: SelectorImpl<AttrString = <Self as MatchAttr>::AttrString>;
+    type Impl: SelectorImpl<AttrValue = <Self as MatchAttr>::AttrValue>;
 
     fn parent_element(&self) -> Option<Self>;
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -6,7 +6,7 @@
 //! style.
 
 use matching::ElementFlags;
-use parser::{AttrSelector, SelectorImpl, TypeConstructor};
+use parser::{AttrSelector, SelectorImpl};
 use std::ascii::AsciiExt;
 use string_cache::{Atom, BorrowedAtom};
 
@@ -139,7 +139,7 @@ pub trait Element: MatchAttr + Sized {
 
     fn is_html_element_in_html_document(&self) -> bool;
     fn get_local_name<'a>(&'a self) -> BorrowedAtom<'a>;
-    fn get_namespace<'a>(&'a self) -> <Self::Impl as TypeConstructor<'a>>::BorrowedNamespace;
+    fn get_namespace<'a>(&'a self) -> &<Self::Impl as SelectorImpl>::BorrowedNamespace;
 
     fn match_non_ts_pseudo_class(&self, pc: <Self::Impl as SelectorImpl>::NonTSPseudoClass) -> bool;
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -8,7 +8,6 @@
 use matching::ElementFlags;
 use parser::{AttrSelector, SelectorImpl};
 use std::ascii::AsciiExt;
-use string_cache::Atom;
 
 /// The definition of whitespace per CSS Selectors Level 3 § 4.
 pub static SELECTOR_WHITESPACE: &'static [char] = &[' ', '\t', '\n', '\r', '\x0C'];
@@ -143,8 +142,8 @@ pub trait Element: MatchAttr + Sized {
 
     fn match_non_ts_pseudo_class(&self, pc: <Self::Impl as SelectorImpl>::NonTSPseudoClass) -> bool;
 
-    fn get_id(&self) -> Option<Atom>;
-    fn has_class(&self, name: &Atom) -> bool;
+    fn get_id(&self) -> Option<<Self::Impl as SelectorImpl>::Identifier>;
+    fn has_class(&self, name: &<Self::Impl as SelectorImpl>::ClassName) -> bool;
 
     /// Returns whether this element matches `:empty`.
     ///
@@ -163,7 +162,7 @@ pub trait Element: MatchAttr + Sized {
     // really messy, since there is a `JSRef` and a `RefCell` involved. Maybe
     // in the future when we have associated types and/or a more convenient
     // JS GC story... --pcwalton
-    fn each_class<F>(&self, callback: F) where F: FnMut(&Atom);
+    fn each_class<F>(&self, callback: F) where F: FnMut(&<Self::Impl as SelectorImpl>::ClassName);
 
     /// Add flags to the element. See the `ElementFlags` docs for details.
     ///

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -6,8 +6,9 @@
 //! style.
 
 use matching::ElementFlags;
-use parser::{AttrSelector, MaybeAtom, SelectorImpl};
+use parser::{AttrSelector, MaybeHeapSizeOf, SelectorImpl};
 use std::ascii::AsciiExt;
+use std::fmt::Debug;
 use string_cache::{Atom, BorrowedAtom, BorrowedNamespace};
 
 /// The definition of whitespace per CSS Selectors Level 3 § 4.
@@ -16,7 +17,7 @@ pub static SELECTOR_WHITESPACE: &'static [char] = &[' ', '\t', '\n', '\r', '\x0C
 // Attribute matching routines. Consumers with simple implementations can implement
 // MatchAttrGeneric instead.
 pub trait MatchAttr {
-    type AttrString: MaybeAtom;
+    type AttrString: Clone + Debug + MaybeHeapSizeOf + PartialEq;
     fn match_attr_has(&self, attr: &AttrSelector) -> bool;
     fn match_attr_equals(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;
     fn match_attr_equals_ignore_ascii_case(&self, attr: &AttrSelector, value: &Self::AttrString) -> bool;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -8,7 +8,7 @@
 use matching::ElementFlags;
 use parser::{AttrSelector, SelectorImpl};
 use std::ascii::AsciiExt;
-use string_cache::{Atom, BorrowedAtom};
+use string_cache::Atom;
 
 /// The definition of whitespace per CSS Selectors Level 3 § 4.
 pub static SELECTOR_WHITESPACE: &'static [char] = &[' ', '\t', '\n', '\r', '\x0C'];
@@ -138,7 +138,7 @@ pub trait Element: MatchAttr + Sized {
     fn next_sibling_element(&self) -> Option<Self>;
 
     fn is_html_element_in_html_document(&self) -> bool;
-    fn get_local_name<'a>(&'a self) -> BorrowedAtom<'a>;
+    fn get_local_name<'a>(&'a self) -> &<Self::Impl as SelectorImpl>::BorrowedLocalName;
     fn get_namespace<'a>(&'a self) -> &<Self::Impl as SelectorImpl>::BorrowedNamespace;
 
     fn match_non_ts_pseudo_class(&self, pc: <Self::Impl as SelectorImpl>::NonTSPseudoClass) -> bool;


### PR DESCRIPTION
Corresponding Servo changes https://github.com/servo/servo/compare/selectors-generic-atom_

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-selectors/92)

<!-- Reviewable:end -->
