### PR TITLE
Disable style sharing in the presence of sibling combinators.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "selectors"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Simon Sapin <simon.sapin@exyr.org>", "Alan Jeffrey <ajeffrey@mozilla.com>"]
 documentation = "http://doc.servo.org/selectors/"
 

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -490,6 +490,7 @@ fn matches_compound_selector_internal<E>(selector: &CompoundSelector<E::Impl>,
                 Combinator::LaterSibling => (true, SelectorMatchingResult::NotMatchedAndRestartFromClosestDescendant),
             };
             let mut next_element = if siblings {
+                *shareable = false;
                 element.prev_sibling_element()
             } else {
                 element.parent_element()


### PR DESCRIPTION
See https://github.com/servo/servo/pull/12571#issuecomment-238536451

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-selectors/94)

<!-- Reviewable:end -->
