### PR TITLE
Fix empty values and values with whitespace in attribute selectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "selectors"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>", "Alan Jeffrey <ajeffrey@mozilla.com>"]
 documentation = "https://docs.rs/selectors/"
 

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -419,6 +419,12 @@ fn matches_simple_selector<E>(
             relation_if!(element.match_attr_suffix(attr, value),
                          AFFECTED_BY_NON_COMMON_STYLE_AFFECTING_ATTRIBUTE_SELECTOR)
         }
+        SimpleSelector::AttrIncludesNeverMatch(..) |
+        SimpleSelector::AttrPrefixNeverMatch(..) |
+        SimpleSelector::AttrSubstringNeverMatch(..) |
+        SimpleSelector::AttrSuffixNeverMatch(..) => {
+            false
+        }
         SimpleSelector::NonTSPseudoClass(ref pc) => {
             relation_if!(element.match_non_ts_pseudo_class(pc.clone()),
                          AFFECTED_BY_STATE)


### PR DESCRIPTION
https://github.com/servo/servo/issues/15394

Also use `?` syntax. I recommend looking at the two commits separately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-selectors/104)
<!-- Reviewable:end -->
