### PR TITLE
Drive-by breaking changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "selectors"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>", "Alan Jeffrey <ajeffrey@mozilla.com>"]
 documentation = "https://docs.rs/selectors/"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,8 @@ readme = "README.md"
 keywords = ["css", "selectors"]
 license = "MPL-2.0"
 
-[features]
-heap_size = ["heapsize", "heapsize_plugin"]
-
 [dependencies]
 bitflags = "0.7"
 matches = "0.1"
 cssparser = ">=0.6, <0.8"
 fnv = "1.0"
-heapsize = {version = "0.3", features = ["unstable"], optional = true}
-heapsize_plugin = {version = "0.1.0", optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![cfg_attr(feature = "heap_size", feature(plugin, custom_derive))]
-#![cfg_attr(feature = "heap_size", plugin(heapsize_plugin))]
-
-#[cfg(feature = "heap_size")] extern crate heapsize;
 #[macro_use] extern crate bitflags;
 #[macro_use] extern crate cssparser;
 #[macro_use] extern crate matches;

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -426,7 +426,7 @@ fn matches_simple_selector<E>(
             false
         }
         SimpleSelector::NonTSPseudoClass(ref pc) => {
-            relation_if!(element.match_non_ts_pseudo_class(pc.clone()),
+            relation_if!(element.match_non_ts_pseudo_class(pc),
                          AFFECTED_BY_STATE)
         }
         SimpleSelector::FirstChild => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -83,20 +83,10 @@ macro_rules! with_bounds {
     }
 }
 
-macro_rules! with_heap_size_bound {
-    ($( $HeapSizeOf: tt )*) => {
-        with_bounds! {
-            [Clone + Eq + Hash $($HeapSizeOf)*]
-            [From<String> + for<'a> From<&'a str>]
-        }
-    }
+with_bounds! {
+    [Clone + Eq + Hash]
+    [From<String> + for<'a> From<&'a str>]
 }
-
-#[cfg(feature = "heap_size")]
-with_heap_size_bound!(+ ::heapsize::HeapSizeOf);
-
-#[cfg(not(feature = "heap_size"))]
-with_heap_size_bound!();
 
 pub trait Parser {
     type Impl: SelectorImpl;
@@ -130,7 +120,6 @@ pub trait Parser {
     }
 }
 
-#[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 #[derive(PartialEq, Clone, Debug)]
 pub struct SelectorList<Impl: SelectorImpl>(pub Vec<Selector<Impl>>);
 
@@ -146,7 +135,6 @@ impl<Impl: SelectorImpl> SelectorList<Impl> {
     }
 }
 
-#[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 #[derive(PartialEq, Clone)]
 pub struct Selector<Impl: SelectorImpl> {
     pub complex_selector: Arc<ComplexSelector<Impl>>,
@@ -234,14 +222,12 @@ impl<Impl: SelectorImpl> ComplexSelector<Impl> {
     }
 }
 
-#[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub struct ComplexSelector<Impl: SelectorImpl> {
     pub compound_selector: Vec<SimpleSelector<Impl>>,
     pub next: Option<(Arc<ComplexSelector<Impl>>, Combinator)>,  // c.next is left of c
 }
 
-#[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 pub enum Combinator {
     Child,  //  >
@@ -250,7 +236,6 @@ pub enum Combinator {
     LaterSibling,  // ~
 }
 
-#[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 #[derive(Eq, PartialEq, Clone, Hash)]
 pub enum SimpleSelector<Impl: SelectorImpl> {
     ID(Impl::Identifier),
@@ -289,7 +274,6 @@ pub enum SimpleSelector<Impl: SelectorImpl> {
 }
 
 #[derive(Eq, PartialEq, Clone, Hash, Copy, Debug)]
-#[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 pub enum CaseSensitivity {
     CaseSensitive,  // Selectors spec says language-defined, but HTML says sensitive.
     CaseInsensitive,
@@ -297,14 +281,12 @@ pub enum CaseSensitivity {
 
 
 #[derive(Eq, PartialEq, Clone, Hash)]
-#[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 pub struct LocalName<Impl: SelectorImpl> {
     pub name: Impl::LocalName,
     pub lower_name: Impl::LocalName,
 }
 
 #[derive(Eq, PartialEq, Clone, Hash)]
-#[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 pub struct AttrSelector<Impl: SelectorImpl> {
     pub name: Impl::LocalName,
     pub lower_name: Impl::LocalName,
@@ -312,7 +294,6 @@ pub struct AttrSelector<Impl: SelectorImpl> {
 }
 
 #[derive(Eq, PartialEq, Clone, Hash, Debug)]
-#[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 pub enum NamespaceConstraint<Impl: SelectorImpl> {
     Any,
     Specific(Namespace<Impl>),
@@ -320,7 +301,6 @@ pub enum NamespaceConstraint<Impl: SelectorImpl> {
 
 /// FIXME(SimonSapin): should Hash only hash the URL? What is it used for?
 #[derive(Eq, PartialEq, Clone, Hash)]
-#[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 pub struct Namespace<Impl: SelectorImpl> {
     pub prefix: Option<Impl::NamespacePrefix>,
     pub url: Impl::NamespaceUrl,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -140,7 +140,7 @@ pub trait Element: MatchAttr + Sized {
     fn get_local_name(&self) -> &<Self::Impl as SelectorImpl>::BorrowedLocalName;
     fn get_namespace(&self) -> &<Self::Impl as SelectorImpl>::BorrowedNamespaceUrl;
 
-    fn match_non_ts_pseudo_class(&self, pc: <Self::Impl as SelectorImpl>::NonTSPseudoClass) -> bool;
+    fn match_non_ts_pseudo_class(&self, pc: &<Self::Impl as SelectorImpl>::NonTSPseudoClass) -> bool;
 
     fn get_id(&self) -> Option<<Self::Impl as SelectorImpl>::Identifier>;
     fn has_class(&self, name: &<Self::Impl as SelectorImpl>::ClassName) -> bool;


### PR DESCRIPTION
Since we’re making a semver-incompatible version anyway (https://github.com/servo/rust-selectors/pull/104) here are a couple other breaking changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-selectors/105)
<!-- Reviewable:end -->
